### PR TITLE
#466 improved step sketch view to be consistent with step view

### DIFF
--- a/scenarioo-client/app/views/sketcher/stepSketch.html
+++ b/scenarioo-client/app/views/sketcher/stepSketch.html
@@ -26,7 +26,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <div class="row sc-space-top sc-space-bottom" ng-hide="loading || issueNotFound">
     <div class="col-sm-8">
-        <h2 class="sc-pageTitle">Sketch for Issue '{{issue.name}}'</h2>
+        <h2 class="sc-pageTitle">Sketch '{{issue.name}}'</h2>
     </div>
     <div class="col-sm-4">
         <sc-meta-data-button class="pull-right" linking-variable="sketchShowMetadata"

--- a/scenarioo-client/app/views/sketcher/stepSketch.html
+++ b/scenarioo-client/app/views/sketcher/stepSketch.html
@@ -24,50 +24,80 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </div>
 </div>
 
-<tabset class="step-panes" ng-hide="loading || issueNotFound">
-    <tab heading="Sketch: {{issue.name}}">
-        <img ng-src={{getScreenShotUrl()}}/>
-    </tab>
-    <tab heading="Original Screenshot">
-        <img ng-src="{{getOriginalScreenshotUrl()}}"/>
-    </tab>
-    <tab heading="Metadata">
-        <h2>Details</h2>
+<div class="row sc-space-top sc-space-bottom" ng-hide="loading || issueNotFound">
+    <div class="col-sm-8">
+        <h2 class="sc-pageTitle">Sketch for Issue '{{issue.name}}'</h2>
+    </div>
+    <div class="col-sm-4">
+        <sc-meta-data-button class="pull-right" linking-variable="sketchShowMetadata"
+                             local-storage-key="stepSketch"></sc-meta-data-button>
+    </div>
+</div>
 
-        <p id="issue-name">
-            Sketch name: {{issue.name}}
-        </p>
+<sc-meta-data-panel linking-variable="sketchShowMetadata" ng-hide="loading || issueNotFound">
 
-        <p id="issue-description">
-            Description: {{issue.description}}
-        </p>
+    <div>
 
-        <p id="author">
-            Author: {{issue.author}}
-        </p>
+        <tabset class="step-panes">
+            <tab heading="Sketch">
+                <img ng-src={{getScreenShotUrl()}} class="sc-screenshot"/>
+            </tab>
+            <tab heading="Original Screenshot">
+                <img ng-src="{{getOriginalScreenshotUrl()}}" class="sc-screenshot"/>
+            </tab>
+        </tabset>
 
-        <p id="dateCreated">
-            Created: {{stepSketch.dateCreated | scDateTime}}
-        </p>
+    </div>
+    <div>
 
-        <p id="dateModified">
-            Last modified: {{stepSketch.dateModified | scDateTime}}
-        </p>
+        <!-- Sketch Details Info -->
+        <sc-collapsable-panel title="Sketch Details" key="stepSketchView-details" initially-expanded="true">
 
-        <h2>Original Step in Documentation</h2>
+            <p id="issue-name">
+                Name: {{issue.name}}
+            </p>
 
-        <p>The sketch is based on this step from the documentation.</p>
+            <p id="issue-description">
+                Description: {{issue.description}}
+            </p>
 
-        <p id="usecase-context">
-            <a ng-href="{{getUseCaseUrl()}}">Use Case: {{stepSketch.relatedStep.usecaseName | scHumanReadable}}</a>
-        </p>
+            <p id="author">
+                Author: {{issue.author}}
+            </p>
 
-        <p id="scenario-context">
-            <a ng-href="{{getScenarioUrl()}}">Scenario: {{stepSketch.relatedStep.scenarioName | scHumanReadable}}</a>
-        </p>
+            <p id="dateCreated">
+                Created: {{stepSketch.dateCreated | scDateTime}}
+            </p>
 
-        <p id="step-context">
-            <a ng-href="{{getStepUrl()}}">Step: {{stepSketch.relatedStep.pageName}}/{{stepSketch.relatedStep.pageOccurrence}}/{{stepSketch.relatedStep.stepInPageOccurrence}}</a>
-        </p>
-    </tab>
-</tabset>
+            <p id="dateModified">
+                Last modified: {{stepSketch.dateModified | scDateTime}}
+            </p>
+
+        </sc-collapsable-panel>
+
+        <!-- Sketch Context Info -->
+        <sc-collapsable-panel title="Sketch Context" key="stepSketchView-context" initially-expanded="true">
+
+            <p>The sketch is based on this step from the documentation.</p>
+            <!-- what is missing: what branch and build ?? -->
+
+            <p id="usecase-context">
+                <a ng-href="{{getUseCaseUrl()}}">Use Case: {{stepSketch.relatedStep.usecaseName | scHumanReadable}}</a>
+            </p>
+
+            <p id="scenario-context">
+                <a ng-href="{{getScenarioUrl()}}">Scenario: {{stepSketch.relatedStep.scenarioName | scHumanReadable}}</a>
+            </p>
+
+            <p id="step-context">
+                <a ng-href="{{getStepUrl()}}">Step: {{stepSketch.relatedStep.pageName}}/{{stepSketch.relatedStep.pageOccurrence}}/{{stepSketch.relatedStep.stepInPageOccurrence}}</a>
+            </p>
+
+        </sc-collapsable-panel>
+
+    </div>
+
+</sc-meta-data-panel>
+
+
+

--- a/scenarioo-client/app/views/sketcher/stepSketch.html
+++ b/scenarioo-client/app/views/sketcher/stepSketch.html
@@ -40,10 +40,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
         <tabset class="step-panes">
             <tab heading="Sketch">
-                <img ng-src={{getScreenShotUrl()}} class="sc-screenshot"/>
+                <div class="sc-screenshot-border">
+                    <img ng-src={{getScreenShotUrl()}} class="sc-screenshot"/>
+                </div>
             </tab>
             <tab heading="Original Screenshot">
-                <img ng-src="{{getOriginalScreenshotUrl()}}" class="sc-screenshot"/>
+                <div class="sc-screenshot-border">
+                    <img ng-src="{{getOriginalScreenshotUrl()}}" class="sc-screenshot"/>
+                </div>
             </tab>
         </tabset>
 


### PR DESCRIPTION
that was very easy ... just needed to change some HTML - all e2e tests still pass and manual testing was successful.

The diff seems to be more changes than I realy did on first view, because I moved some existing html blocks into the metadata panel and some collapsable panels. Actualy it was not that much as it might look.

It is exactly the same now, as on other pages (e.g. usecase.html) and that should work without problems. also the image has now a scalable style and a nice border (exactly same as for step view).

@adiherzog If you agree I want to merge this for the release.

See #466 for how it looks