### PR TITLE
Fulltext Search Improvements

### DIFF
--- a/scenarioo-client/app/search/search.controller.js
+++ b/scenarioo-client/app/search/search.controller.js
@@ -41,7 +41,9 @@ angular.module('scenarioo.controllers').controller('SearchController', function 
                 vm.showSearchFailed = true;
                 vm.errorMessage = response.errorMessage;
             } else {
-                vm.results.resultSet = response.results;
+                vm.results.resultSet = response.searchTree.results;
+                vm.hits = response.searchTree.hits;
+                vm.totalHits = response.searchTree.totalHits;
             }
         },
         function onError(error) {

--- a/scenarioo-client/app/search/search.controller.js
+++ b/scenarioo-client/app/search/search.controller.js
@@ -22,6 +22,7 @@ angular.module('scenarioo.controllers').controller('SearchController', function 
     vm.results = {resultSet: []};
     vm.errorMessage = '';
     vm.searchTerm = $routeParams.searchTerm;
+    vm.includeHtml = $location.search().includeHtml;
     vm.treemodel = [];
     vm.showSearchFailed = false;
     vm.goToRelatedView = goToRelatedView;
@@ -33,6 +34,7 @@ angular.module('scenarioo.controllers').controller('SearchController', function 
 
         FullTextSearchService.search({
                 q: vm.searchTerm,
+                includeHtml: vm.includeHtml,
                 buildName: selected.build,
                 branchName: selected.branch
             }

--- a/scenarioo-client/app/search/search.html
+++ b/scenarioo-client/app/search/search.html
@@ -25,7 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
      data-treedata="vm.results.resultSet.children"
      data-treemodel="vm.treemodel"
      data-click-action="vm.goToRelatedView(node)"
-     data-first-column-title="Search Results"
+     data-first-column-title="Search Results (showing {{vm.hits}} of {{vm.totalHits}} hits)"
      ng-show="vm.results.resultSet.children.length > 0">
 </div>
 

--- a/scenarioo-client/app/shared/navigation/navigation.controller.js
+++ b/scenarioo-client/app/shared/navigation/navigation.controller.js
@@ -39,7 +39,8 @@ function NavigationController($scope, $location, LocalStorageService, BranchesAn
     };
 
     $scope.search = function () {
-        var searchTerm = $scope.globalSearch.queryString;
+        var searchTerm = $scope.globalSearch.queryString,
+            includeHtml = !!$scope.globalSearch.includeHtml;
 
         // If the search term is blank nothing happens
         if(!angular.isString(searchTerm) || searchTerm.trim() === '') {
@@ -52,7 +53,7 @@ function NavigationController($scope, $location, LocalStorageService, BranchesAn
             return;
         }
 
-        $location.path('/search/' + searchTerm);
+        $location.url('/search/' + searchTerm + '?includeHtml=' + includeHtml);
     };
 
     function loadSearchEngineRunning () {
@@ -163,5 +164,5 @@ function NavigationController($scope, $location, LocalStorageService, BranchesAn
     $scope.showApplicationInfoPopup = function () {
         ApplicationInfoPopupService.showApplicationInfoPopup();
     };
-    
+
 }

--- a/scenarioo-client/app/shared/navigation/navigation.html
+++ b/scenarioo-client/app/shared/navigation/navigation.html
@@ -101,6 +101,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         </button>
                     </span>
                     <input id="sc-global-search-box-textfield" class="form-control input-sm" ng-model="globalSearch.queryString" type="text">
+                    <span class="input-group-addon">
+                        <input type="checkbox" ng-model="globalSearch.includeHtml"> HTML?
+                    </span>
                 </div>
             </form>
         </li>

--- a/scenarioo-client/app/shared/restServices.js
+++ b/scenarioo-client/app/shared/restServices.js
@@ -128,7 +128,8 @@ angular.module('scenarioo.services')
             {
                 branchName: '@branchName',
                 buildName: '@buildName',
-                q: '@q'
+                q: '@q',
+                includeHtml: '@includeHtml'
             }, {});
 
         searchService.search = getPromise($q, function (parameters, fnSuccess, fnError) {

--- a/scenarioo-client/test/protractorE2E/specs/full_text_search.js
+++ b/scenarioo-client/test/protractorE2E/specs/full_text_search.js
@@ -30,7 +30,7 @@ useCase('Full Text Search')
             .description('Search for a term that yealds some results.')
             .it(function() {
                 homePage.goToPage();
-                navigationPage.enterSearchTerm('donate');
+                navigationPage.enterSearchTerm('donate.jsp');
                 step('Search term entered');
 
                 navigationPage.clickSearchButton();

--- a/scenarioo-client/test/protractorE2E/webPages/searchResultsPage.js
+++ b/scenarioo-client/test/protractorE2E/webPages/searchResultsPage.js
@@ -23,7 +23,7 @@ SearchResultsPage.prototype.clickSearchButton = function() {
 };
 
 SearchResultsPage.prototype.assertResultTableTitle = function() {
-    expect(element(by.id('sc-treeviewtable-title')).getText()).toBe('Search Results (showing 2 of 2 hits)');
+    expect(element(by.id('sc-treeviewtable-title')).getText()).toBe('Search Results (showing 1 of 1 hits)');
 };
 
 SearchResultsPage.prototype.assertNumberOfResultRows = function(expectedNumber) {

--- a/scenarioo-client/test/protractorE2E/webPages/searchResultsPage.js
+++ b/scenarioo-client/test/protractorE2E/webPages/searchResultsPage.js
@@ -23,7 +23,7 @@ SearchResultsPage.prototype.clickSearchButton = function() {
 };
 
 SearchResultsPage.prototype.assertResultTableTitle = function() {
-    expect(element(by.id('sc-treeviewtable-title')).getText()).toBe('Search Results');
+    expect(element(by.id('sc-treeviewtable-title')).getText()).toBe('Search Results (showing 2 of 2 hits)');
 };
 
 SearchResultsPage.prototype.assertNumberOfResultRows = function(expectedNumber) {

--- a/scenarioo-server/src/main/java/org/scenarioo/dao/search/FullTextSearch.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/dao/search/FullTextSearch.java
@@ -30,6 +30,7 @@ import org.scenarioo.model.docu.entities.Scenario;
 import org.scenarioo.model.docu.entities.Step;
 import org.scenarioo.model.docu.entities.UseCase;
 import org.scenarioo.rest.base.BuildIdentifier;
+import org.scenarioo.rest.search.SearchRequest;
 
 public class FullTextSearch {
 
@@ -60,7 +61,7 @@ public class FullTextSearch {
 		return searchAdapter.isSearchEndpointConfigured();
 	}
 
-	public SearchTree search(final String q, final BuildIdentifier buildIdentifier) {
+	public SearchTree search(SearchRequest searchRequest) {
 		if(!searchAdapter.isEngineRunning()) {
 			throw new SearchEngineNotRunningException();
 		}
@@ -68,12 +69,12 @@ public class FullTextSearch {
 		SearchResultsDao searchResults;
 
 		try {
-			searchResults = searchAdapter.searchData(buildIdentifier, q);
+			searchResults = searchAdapter.searchData(searchRequest);
 		} catch (Throwable t) {
 			throw new SearchFailedException(t);
 		}
 
-		return new SearchTree(searchResults, q);
+		return new SearchTree(searchResults, searchRequest);
 	}
 
 	public void indexUseCases(final UseCaseScenariosList useCaseScenariosList, final BuildIdentifier buildIdentifier) {

--- a/scenarioo-server/src/main/java/org/scenarioo/dao/search/FullTextSearch.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/dao/search/FullTextSearch.java
@@ -21,7 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.log4j.Logger;
-import org.scenarioo.dao.search.dao.SearchDao;
+import org.scenarioo.dao.search.dao.SearchResultsDao;
 import org.scenarioo.dao.search.elasticsearch.ElasticSearchAdapter;
 import org.scenarioo.model.docu.aggregates.branches.BuildImportSummary;
 import org.scenarioo.model.docu.aggregates.steps.StepLink;
@@ -65,7 +65,7 @@ public class FullTextSearch {
 			throw new SearchEngineNotRunningException();
 		}
 
-		List<SearchDao> searchResults;
+		SearchResultsDao searchResults;
 
 		try {
 			searchResults = searchAdapter.searchData(buildIdentifier, q);

--- a/scenarioo-server/src/main/java/org/scenarioo/dao/search/SearchAdapter.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/dao/search/SearchAdapter.java
@@ -19,7 +19,7 @@ package org.scenarioo.dao.search;
 
 import java.util.List;
 
-import org.scenarioo.dao.search.dao.SearchDao;
+import org.scenarioo.dao.search.dao.SearchResultsDao;
 import org.scenarioo.model.docu.aggregates.steps.StepLink;
 import org.scenarioo.model.docu.aggregates.usecases.UseCaseScenariosList;
 import org.scenarioo.model.docu.entities.Scenario;
@@ -35,7 +35,7 @@ public interface SearchAdapter {
 
 	String getEndpoint();
 
-    List<SearchDao> searchData(BuildIdentifier buildIdentifier, String q);
+    SearchResultsDao searchData(BuildIdentifier buildIdentifier, String q);
 
     void indexUseCases(UseCaseScenariosList useCaseScenariosList, BuildIdentifier buildIdentifier);
 

--- a/scenarioo-server/src/main/java/org/scenarioo/dao/search/SearchAdapter.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/dao/search/SearchAdapter.java
@@ -26,6 +26,7 @@ import org.scenarioo.model.docu.entities.Scenario;
 import org.scenarioo.model.docu.entities.Step;
 import org.scenarioo.model.docu.entities.UseCase;
 import org.scenarioo.rest.base.BuildIdentifier;
+import org.scenarioo.rest.search.SearchRequest;
 
 public interface SearchAdapter {
 
@@ -35,7 +36,7 @@ public interface SearchAdapter {
 
 	String getEndpoint();
 
-    SearchResultsDao searchData(BuildIdentifier buildIdentifier, String q);
+    SearchResultsDao searchData(SearchRequest searchRequest);
 
     void indexUseCases(UseCaseScenariosList useCaseScenariosList, BuildIdentifier buildIdentifier);
 

--- a/scenarioo-server/src/main/java/org/scenarioo/dao/search/SearchTree.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/dao/search/SearchTree.java
@@ -21,25 +21,42 @@ import org.scenarioo.dao.search.dao.*;
 import org.scenarioo.model.docu.entities.generic.ObjectReference;
 import org.scenarioo.model.docu.entities.generic.ObjectTreeNode;
 
-import java.util.Collections;
-import java.util.List;
-
 public class SearchTree {
-	private List<SearchDao> searchResults;
-	private String q;
+	private final ObjectTreeNode<ObjectReference> results;
+	private final long hits;
+	private final long totalHits;
+	private final String q;
 
 	public static SearchTree empty() {
-		return new SearchTree(Collections.<SearchDao>emptyList(), "");
+		return new SearchTree(SearchResultsDao.noHits(), "");
 	}
 
-	public SearchTree(List<SearchDao> searchResults, String q) {
-		this.searchResults = searchResults;
+	public SearchTree(SearchResultsDao searchResults, String q) {
+		this.results = buildObjectTree(searchResults);
+		this.hits = searchResults.getHits();
+		this.totalHits = searchResults.getTotalHits();
 		this.q = q;
 	}
 
-	public ObjectTreeNode<ObjectReference> buildObjectTree() {
+	public ObjectTreeNode<ObjectReference> getResults() {
+		return results;
+	}
+
+	public long getHits() {
+		return hits;
+	}
+
+	public long getTotalHits() {
+		return totalHits;
+	}
+
+	public String getQ() {
+		return q;
+	}
+
+	private ObjectTreeNode<ObjectReference> buildObjectTree(SearchResultsDao searchResults) {
 		ObjectTreeNode<ObjectReference> rootNode = new ObjectTreeNode<ObjectReference>(new ObjectReference("search", q));
-		for (SearchDao entry : searchResults) {
+		for (SearchDao entry : searchResults.getResults()) {
 			addNode(rootNode, entry);
 		}
 		return rootNode;

--- a/scenarioo-server/src/main/java/org/scenarioo/dao/search/SearchTree.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/dao/search/SearchTree.java
@@ -20,22 +20,25 @@ package org.scenarioo.dao.search;
 import org.scenarioo.dao.search.dao.*;
 import org.scenarioo.model.docu.entities.generic.ObjectReference;
 import org.scenarioo.model.docu.entities.generic.ObjectTreeNode;
+import org.scenarioo.rest.base.BuildIdentifier;
+import org.scenarioo.rest.search.SearchRequest;
 
 public class SearchTree {
 	private final ObjectTreeNode<ObjectReference> results;
 	private final long hits;
 	private final long totalHits;
-	private final String q;
+	private final SearchRequest searchRequest;
 
 	public static SearchTree empty() {
-		return new SearchTree(SearchResultsDao.noHits(), "");
+		return new SearchTree(SearchResultsDao.noHits(), new SearchRequest(new BuildIdentifier(), "", true));
 	}
 
-	public SearchTree(SearchResultsDao searchResults, String q) {
-		this.results = buildObjectTree(searchResults);
+	public SearchTree(SearchResultsDao searchResults, SearchRequest searchRequest) {
 		this.hits = searchResults.getHits();
 		this.totalHits = searchResults.getTotalHits();
-		this.q = q;
+		this.searchRequest = searchRequest;
+
+		this.results = buildObjectTree(searchResults);
 	}
 
 	public ObjectTreeNode<ObjectReference> getResults() {
@@ -50,12 +53,12 @@ public class SearchTree {
 		return totalHits;
 	}
 
-	public String getQ() {
-		return q;
+	public SearchRequest getSearchRequest() {
+		return searchRequest;
 	}
 
 	private ObjectTreeNode<ObjectReference> buildObjectTree(SearchResultsDao searchResults) {
-		ObjectTreeNode<ObjectReference> rootNode = new ObjectTreeNode<ObjectReference>(new ObjectReference("search", q));
+		ObjectTreeNode<ObjectReference> rootNode = new ObjectTreeNode<>(new ObjectReference("search", searchRequest.getQ()));
 		for (SearchDao entry : searchResults.getResults()) {
 			addNode(rootNode, entry);
 		}

--- a/scenarioo-server/src/main/java/org/scenarioo/dao/search/dao/SearchResultsDao.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/dao/search/dao/SearchResultsDao.java
@@ -1,0 +1,50 @@
+/* scenarioo-server
+ * Copyright (C) 2014, scenarioo.org Development Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.scenarioo.dao.search.dao;
+
+import java.util.Collections;
+import java.util.List;
+
+public class SearchResultsDao {
+
+	private final List<SearchDao> results;
+	private final long hits;
+	private long totalHits;
+
+	public static SearchResultsDao noHits() {
+		return new SearchResultsDao(Collections.<SearchDao>emptyList(), 0, 0);
+	}
+
+	public SearchResultsDao(List<SearchDao> results, long hits, long totalHits) {
+		this.results = results;
+		this.totalHits = totalHits;
+		this.hits = hits;
+	}
+
+	public long getHits() {
+		return hits;
+	}
+
+	public long getTotalHits() {
+		return totalHits;
+	}
+
+	public List<SearchDao> getResults() {
+		return results;
+	}
+}

--- a/scenarioo-server/src/main/java/org/scenarioo/dao/search/elasticsearch/ElasticSearchAdapter.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/dao/search/elasticsearch/ElasticSearchAdapter.java
@@ -31,7 +31,7 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.scenarioo.dao.search.SearchAdapter;
-import org.scenarioo.dao.search.dao.SearchDao;
+import org.scenarioo.dao.search.dao.SearchResultsDao;
 import org.scenarioo.model.docu.aggregates.steps.StepLink;
 import org.scenarioo.model.docu.aggregates.usecases.UseCaseScenariosList;
 import org.scenarioo.model.docu.entities.Scenario;
@@ -105,7 +105,7 @@ public class ElasticSearchAdapter implements SearchAdapter {
 	}
 
     @Override
-    public List<SearchDao> searchData(final BuildIdentifier buildIdentifier, final String q) {
+    public SearchResultsDao searchData(final BuildIdentifier buildIdentifier, final String q) {
         final String indexName = getIndexName(buildIdentifier);
 
         ElasticSearchSearcher elasticSearchSearcher = new ElasticSearchSearcher(indexName);

--- a/scenarioo-server/src/main/java/org/scenarioo/dao/search/elasticsearch/ElasticSearchAdapter.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/dao/search/elasticsearch/ElasticSearchAdapter.java
@@ -43,6 +43,7 @@ import org.scenarioo.rest.application.ContextPathHolder;
 import org.scenarioo.rest.base.BuildIdentifier;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
+import org.scenarioo.rest.search.SearchRequest;
 
 public class ElasticSearchAdapter implements SearchAdapter {
     private final static Logger LOGGER = Logger.getLogger(ElasticSearchAdapter.class);
@@ -105,11 +106,11 @@ public class ElasticSearchAdapter implements SearchAdapter {
 	}
 
     @Override
-    public SearchResultsDao searchData(final BuildIdentifier buildIdentifier, final String q) {
-        final String indexName = getIndexName(buildIdentifier);
+    public SearchResultsDao searchData(final SearchRequest searchRequest) {
+        final String indexName = getIndexName(searchRequest.getBuildIdentifier());
 
         ElasticSearchSearcher elasticSearchSearcher = new ElasticSearchSearcher(indexName);
-        return elasticSearchSearcher.search(q);
+        return elasticSearchSearcher.search(searchRequest);
     }
 
     @Override

--- a/scenarioo-server/src/main/java/org/scenarioo/dao/search/elasticsearch/ElasticSearchIndexer.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/dao/search/elasticsearch/ElasticSearchIndexer.java
@@ -131,7 +131,17 @@ class ElasticSearchIndexer {
                 "					}" +
                 "				}" +
                 "			}" +
-                "		]" +
+                "		]," +
+				"		\"properties\": {" +
+				"			\"step\": {" +
+				"				\"properties\": {" +
+				"					\"html\": {" +
+				"						\"type\": \"object\"," +
+				"						\"include_in_all\": false" +
+				"					}" +
+				"				}" +
+				"			}" +
+				"		}" +
                 "	}" +
                 "}";
     }

--- a/scenarioo-server/src/main/java/org/scenarioo/dao/search/elasticsearch/ElasticSearchSearcher.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/dao/search/elasticsearch/ElasticSearchSearcher.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.log4j.Logger;
@@ -39,10 +38,7 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
 import org.scenarioo.dao.search.FullTextSearch;
 import org.scenarioo.dao.search.IgnoreUseCaseSetStatusMixIn;
-import org.scenarioo.dao.search.dao.ScenarioSearchDao;
-import org.scenarioo.dao.search.dao.SearchDao;
-import org.scenarioo.dao.search.dao.StepSearchDao;
-import org.scenarioo.dao.search.dao.UseCaseSearchDao;
+import org.scenarioo.dao.search.dao.*;
 import org.scenarioo.model.docu.entities.Scenario;
 import org.scenarioo.model.docu.entities.StepDescription;
 import org.scenarioo.model.docu.entities.UseCase;
@@ -74,12 +70,12 @@ class ElasticSearchSearcher {
         }
     }
 
-    List<SearchDao> search(final String q) {
+    SearchResultsDao search(final String q) {
         SearchResponse searchResponse = executeSearch(q);
 
         if (searchResponse.getHits().getHits().length == 0) {
             LOGGER.debug("No results found for " + q);
-            return Collections.emptyList();
+            return SearchResultsDao.noHits();
         }
 
         SearchHit[] hits = searchResponse.getHits().getHits();
@@ -105,7 +101,7 @@ class ElasticSearchSearcher {
             }
         }
 
-        return results;
+        return new SearchResultsDao(results, hits.length, searchResponse.getHits().getTotalHits());
     }
 
     private SearchResponse executeSearch(final String q) {

--- a/scenarioo-server/src/main/java/org/scenarioo/dao/search/elasticsearch/ElasticSearchSearcher.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/dao/search/elasticsearch/ElasticSearchSearcher.java
@@ -33,6 +33,8 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.elasticsearch.common.unit.Fuzziness;
+import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
 import org.scenarioo.dao.search.FullTextSearch;
@@ -109,8 +111,10 @@ class ElasticSearchSearcher {
         LOGGER.debug("Search in index " + indexName + " for " + q);
         SearchRequestBuilder setQuery = client.prepareSearch()
                 .setIndices(indexName)
-                .setSearchType(SearchType.QUERY_AND_FETCH)
-                .setQuery(QueryBuilders.queryStringQuery("*" + q + "*"));
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
+				.setQuery(QueryBuilders.matchQuery("_all", q)
+					.fuzziness(Fuzziness.AUTO)
+					.operator(MatchQueryBuilder.Operator.AND));
 
         return setQuery.execute().actionGet();
     }

--- a/scenarioo-server/src/main/java/org/scenarioo/dao/search/elasticsearch/ElasticSearchSearcher.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/dao/search/elasticsearch/ElasticSearchSearcher.java
@@ -49,6 +49,7 @@ import org.scenarioo.model.docu.entities.UseCase;
 
 class ElasticSearchSearcher {
 	private final static Logger LOGGER = Logger.getLogger(ElasticSearchSearcher.class);
+	private final static int MAX_SEARCH_RESULTS = 200;
 
 	private String indexName;
     private TransportClient client;
@@ -112,6 +113,7 @@ class ElasticSearchSearcher {
         SearchRequestBuilder setQuery = client.prepareSearch()
                 .setIndices(indexName)
                 .setSearchType(SearchType.QUERY_THEN_FETCH)
+				.setSize(MAX_SEARCH_RESULTS)
 				.setQuery(QueryBuilders.matchQuery("_all", q)
 					.fuzziness(Fuzziness.AUTO)
 					.operator(MatchQueryBuilder.Operator.AND));

--- a/scenarioo-server/src/main/java/org/scenarioo/rest/search/SearchRequest.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/rest/search/SearchRequest.java
@@ -1,0 +1,27 @@
+package org.scenarioo.rest.search;
+
+import org.scenarioo.rest.base.BuildIdentifier;
+
+public class SearchRequest {
+	private final BuildIdentifier buildIdentifier;
+	private final String q;
+	private final boolean includeHtml;
+
+    public SearchRequest(BuildIdentifier buildIdentifier, String q, boolean includeHtml) {
+        this.q = q;
+        this.buildIdentifier = buildIdentifier;
+		this.includeHtml = includeHtml;
+    }
+
+    public String getQ() {
+        return q;
+    }
+
+    public BuildIdentifier getBuildIdentifier() {
+        return buildIdentifier;
+    }
+
+	public boolean includeHtml() {
+		return includeHtml;
+	}
+}

--- a/scenarioo-server/src/main/java/org/scenarioo/rest/search/SearchResource.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/rest/search/SearchResource.java
@@ -25,10 +25,9 @@ import javax.ws.rs.Produces;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.scenarioo.business.builds.ScenarioDocuBuildsManager;
 import org.scenarioo.dao.search.FullTextSearch;
+import org.scenarioo.dao.search.SearchTree;
 import org.scenarioo.dao.search.SearchEngineNotRunningException;
 import org.scenarioo.dao.search.SearchFailedException;
-import org.scenarioo.model.docu.entities.generic.ObjectReference;
-import org.scenarioo.model.docu.entities.generic.ObjectTreeNode;
 import org.scenarioo.rest.base.BuildIdentifier;
 
 @Path("/rest")
@@ -45,7 +44,7 @@ public class SearchResource {
 
 		FullTextSearch search = new FullTextSearch();
 		try {
-			ObjectTreeNode<ObjectReference> results = search.search(q, buildIdentifier).buildObjectTree();
+			SearchTree results = search.search(q, buildIdentifier);
 			return new SearchResponse(results);
 		} catch (IndexNotFoundException e) {
 			return new SearchResponse("The search index was not found for the selected build.");

--- a/scenarioo-server/src/main/java/org/scenarioo/rest/search/SearchResource.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/rest/search/SearchResource.java
@@ -17,17 +17,11 @@
 
 package org.scenarioo.rest.search;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 
 import org.elasticsearch.index.IndexNotFoundException;
 import org.scenarioo.business.builds.ScenarioDocuBuildsManager;
-import org.scenarioo.dao.search.FullTextSearch;
-import org.scenarioo.dao.search.SearchTree;
-import org.scenarioo.dao.search.SearchEngineNotRunningException;
-import org.scenarioo.dao.search.SearchFailedException;
+import org.scenarioo.dao.search.*;
 import org.scenarioo.rest.base.BuildIdentifier;
 
 @Path("/rest")
@@ -37,14 +31,15 @@ public class SearchResource {
 	@Produces("application/json")
 	@Path("/branch/{branchName}/build/{buildName}/search/{q}")
 	public SearchResponse search(@PathParam("branchName") final String branchName,
-												  @PathParam("buildName") final String buildName, @PathParam("q") final String q) {
+								 @PathParam("buildName") final String buildName, @PathParam("q") final String q,
+								 @QueryParam("includeHtml") boolean includeHtml) {
 
 		BuildIdentifier buildIdentifier = ScenarioDocuBuildsManager.INSTANCE.resolveBranchAndBuildAliases(branchName,
 				buildName);
 
 		FullTextSearch search = new FullTextSearch();
 		try {
-			SearchTree results = search.search(q, buildIdentifier);
+			SearchTree results = search.search(new SearchRequest(buildIdentifier, q, includeHtml));
 			return new SearchResponse(results);
 		} catch (IndexNotFoundException e) {
 			return new SearchResponse("The search index was not found for the selected build.");

--- a/scenarioo-server/src/main/java/org/scenarioo/rest/search/SearchResponse.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/rest/search/SearchResponse.java
@@ -2,33 +2,32 @@ package org.scenarioo.rest.search;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
-import org.scenarioo.model.docu.entities.generic.ObjectReference;
-import org.scenarioo.model.docu.entities.generic.ObjectTreeNode;
+import org.scenarioo.dao.search.SearchTree;
 
 @XmlRootElement
 public class SearchResponse {
 
-	private ObjectTreeNode<ObjectReference> results;
+	private SearchTree searchTree;
 	private String errorMessage;
 
 	public SearchResponse() {
 		// for serializer
 	}
-	
-	public SearchResponse(final ObjectTreeNode<ObjectReference> results) {
-		this.setResults(results);
+
+	public SearchResponse(final SearchTree searchTree) {
+		this.setSearchTree(searchTree);
 	}
 
 	public SearchResponse(final String errorMessage) {
 		this.setErrorMessage(errorMessage);
 	}
 
-	public ObjectTreeNode<ObjectReference> getResults() {
-		return results;
+	public SearchTree getSearchTree() {
+		return searchTree;
 	}
 
-	public void setResults(ObjectTreeNode<ObjectReference> results) {
-		this.results = results;
+	public void setSearchTree(SearchTree searchTree) {
+		this.searchTree = searchTree;
 	}
 
 	public String getErrorMessage() {

--- a/scenarioo-server/src/test/java/org/scenarioo/dao/search/FullTextSearchTest.java
+++ b/scenarioo-server/src/test/java/org/scenarioo/dao/search/FullTextSearchTest.java
@@ -6,7 +6,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
-import org.scenarioo.dao.search.dao.SearchDao;
+import org.scenarioo.dao.search.dao.SearchResultsDao;
 import org.scenarioo.model.docu.aggregates.branches.BuildImportSummary;
 import org.scenarioo.model.docu.aggregates.steps.StepLink;
 import org.scenarioo.model.docu.aggregates.usecases.UseCaseScenariosList;
@@ -44,7 +44,8 @@ public class FullTextSearchTest {
     public void searchWithNoResults() {
         givenRunningEngineWithSearchResults();
         SearchTree result = fullTextSearch.search("IDONOTEXIST", new BuildIdentifier("testBranch", "testBuild"));
-		assertEquals(0, result.buildObjectTree().getChildren().size());
+		assertEquals(0, result.getResults().getChildren().size());
+		assertEquals(0, result.getTotalHits());
     }
 
     private void givenNoRunningEngine() {
@@ -73,10 +74,10 @@ public class FullTextSearchTest {
         }
 
         @Override
-        public List<SearchDao> searchData(final BuildIdentifier buildIdentifier, final String q) {
+        public SearchResultsDao searchData(final BuildIdentifier buildIdentifier, final String q) {
 			assertTrue("Should not be reachable", isRunning);
 
-            return Collections.emptyList();
+            return SearchResultsDao.noHits();
         }
 
         @Override

--- a/scenarioo-server/src/test/java/org/scenarioo/dao/search/FullTextSearchTest.java
+++ b/scenarioo-server/src/test/java/org/scenarioo/dao/search/FullTextSearchTest.java
@@ -14,6 +14,7 @@ import org.scenarioo.model.docu.entities.Scenario;
 import org.scenarioo.model.docu.entities.Step;
 import org.scenarioo.model.docu.entities.UseCase;
 import org.scenarioo.rest.base.BuildIdentifier;
+import org.scenarioo.rest.search.SearchRequest;
 
 
 public class FullTextSearchTest {
@@ -30,7 +31,7 @@ public class FullTextSearchTest {
 	@Test(expected = SearchEngineNotRunningException.class)
     public void searchWithoutRunningEngine() {
         givenNoRunningEngine();
-        fullTextSearch.search("hi", new BuildIdentifier("testBranch", "testBuild"));
+        fullTextSearch.search(new SearchRequest(new BuildIdentifier("testBranch", "testBuild"), "hi", true));
     }
 
     @Test
@@ -43,7 +44,7 @@ public class FullTextSearchTest {
     @Test
     public void searchWithNoResults() {
         givenRunningEngineWithSearchResults();
-        SearchTree result = fullTextSearch.search("IDONOTEXIST", new BuildIdentifier("testBranch", "testBuild"));
+        SearchTree result = fullTextSearch.search(new SearchRequest(new BuildIdentifier("testBranch", "testBuild"), "IDONOTEXIST", true));
 		assertEquals(0, result.getResults().getChildren().size());
 		assertEquals(0, result.getTotalHits());
     }
@@ -74,7 +75,7 @@ public class FullTextSearchTest {
         }
 
         @Override
-        public SearchResultsDao searchData(final BuildIdentifier buildIdentifier, final String q) {
+        public SearchResultsDao searchData(final SearchRequest searchRequest) {
 			assertTrue("Should not be reachable", isRunning);
 
             return SearchResultsDao.noHits();

--- a/scenarioo-server/src/test/java/org/scenarioo/dao/search/SearchTreeTest.java
+++ b/scenarioo-server/src/test/java/org/scenarioo/dao/search/SearchTreeTest.java
@@ -2,6 +2,7 @@ package org.scenarioo.dao.search;
 
 import org.junit.Test;
 import org.scenarioo.dao.search.dao.SearchDao;
+import org.scenarioo.dao.search.dao.SearchResultsDao;
 import org.scenarioo.dao.search.dao.StepSearchDao;
 import org.scenarioo.model.docu.aggregates.steps.StepLink;
 import org.scenarioo.model.docu.entities.*;
@@ -19,7 +20,7 @@ public class SearchTreeTest {
 	public void emptyTree() {
 		SearchTree searchTree = SearchTree.empty();
 
-		ObjectTreeNode<ObjectReference> objectTree = searchTree.buildObjectTree();
+		ObjectTreeNode<ObjectReference> objectTree = searchTree.getResults();
 
 		assertEquals(0, objectTree.getChildren().size());
 	}
@@ -28,7 +29,7 @@ public class SearchTreeTest {
 	public void treeWithASingleStep() {
 		SearchTree searchTree = givenSearchTreeWithSingleStep();
 
-		ObjectTreeNode<ObjectReference> objectTree = searchTree.buildObjectTree();
+		ObjectTreeNode<ObjectReference> objectTree = searchTree.getResults();
 
 		thenHasNodes(objectTree, "Use Case 1", "Scenario 1", "Page 1/3/2");
 	}
@@ -56,7 +57,7 @@ public class SearchTreeTest {
 		List<SearchDao> searchResults = new ArrayList<SearchDao>();
 		searchResults.add(new StepSearchDao(step, stepLink, scenario, usecase));
 
-		return new SearchTree(searchResults, "");
+		return new SearchTree(new SearchResultsDao(searchResults, 4, 2), "");
 	}
 
 	private void thenHasNodes(ObjectTreeNode<ObjectReference> objectTree, String useCase, String scenario, String step) {

--- a/scenarioo-server/src/test/java/org/scenarioo/dao/search/SearchTreeTest.java
+++ b/scenarioo-server/src/test/java/org/scenarioo/dao/search/SearchTreeTest.java
@@ -8,6 +8,8 @@ import org.scenarioo.model.docu.aggregates.steps.StepLink;
 import org.scenarioo.model.docu.entities.*;
 import org.scenarioo.model.docu.entities.generic.ObjectReference;
 import org.scenarioo.model.docu.entities.generic.ObjectTreeNode;
+import org.scenarioo.rest.base.BuildIdentifier;
+import org.scenarioo.rest.search.SearchRequest;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -57,7 +59,7 @@ public class SearchTreeTest {
 		List<SearchDao> searchResults = new ArrayList<SearchDao>();
 		searchResults.add(new StepSearchDao(step, stepLink, scenario, usecase));
 
-		return new SearchTree(new SearchResultsDao(searchResults, 4, 2), "");
+		return new SearchTree(new SearchResultsDao(searchResults, 4, 2), new SearchRequest(new BuildIdentifier(), "", false));
 	}
 
 	private void thenHasNodes(ObjectTreeNode<ObjectReference> objectTree, String useCase, String scenario, String step) {


### PR DESCRIPTION
And another pull request!

Highlights include:
- Better search results thanks to fuzzy search with an "AND" logic instead of term search! This means slight typos (for example "donat" instead of "donate" will still find a result). The AND logic means that all terms in the search query have to match something, otherwise no result is found. I guess this is what a Scenarioo user wants in most cases.
- More search results! Before scenarioo only returned the default number of search results (which is 10). Now it returns 200. It also shows in the search results how many results are shown and how many are found ("showing X of Y hits"). We might want to extend this with a paging functionality in the future (Elasticsearch should support that more or less out of the box). Maybe we should also make the 200 results configurable.
- Add an (very ugly) option to include HTML in the search or not! Yes, it really is that ugly...
