### PR TITLE
Declare security role in web.xml

### DIFF
--- a/scenarioo-server/src/main/webapp/WEB-INF/web.xml
+++ b/scenarioo-server/src/main/webapp/WEB-INF/web.xml
@@ -60,6 +60,7 @@
 	
 	<security-role>
 		<role-name>scenarioo-build-publisher</role-name>
+		<description>Users with this role are allowed to upload new builds (=report content) to scenarioo using the upload build REST endpoint.</description>
 	</security-role>
 
 	<login-config>

--- a/scenarioo-server/src/main/webapp/WEB-INF/web.xml
+++ b/scenarioo-server/src/main/webapp/WEB-INF/web.xml
@@ -57,6 +57,10 @@
 			<transport-guarantee>NONE</transport-guarantee>
 		</user-data-constraint>
 	</security-constraint>
+	
+	<security-role>
+		<role-name>scenarioo-build-publisher</role-name>
+	</security-role>
 
 	<login-config>
 		<auth-method>BASIC</auth-method>


### PR DESCRIPTION
Avoid warning during Tomcat startup.

From the web-app.xsd documentation :

The role-name used here must either correspond to the role-name of one
of the security-role elements defined for this web application,
or be the specially	reserved role-name "*" that is a compact syntax for
indicating all roles in the web application.