### PR TITLE
#657 fix and improve comparison screenshot title

### DIFF
--- a/scenarioo-client/app/diffViewer/screenshotTitle/screenshotTitle.directive.js
+++ b/scenarioo-client/app/diffViewer/screenshotTitle/screenshotTitle.directive.js
@@ -26,7 +26,7 @@ function scScreenshotTitle() {
             name: '@',
             alias: '@'
         },
-        templateUrl: 'diffViewer/screenshotTitle/screenshotTitle.html'
+        template: require('./screenshotTitle.html')
     };
 }
 

--- a/scenarioo-client/app/diffViewer/screenshotTitle/screenshotTitle.html
+++ b/scenarioo-client/app/diffViewer/screenshotTitle/screenshotTitle.html
@@ -1,6 +1,12 @@
 <h3>
-    {{name}}:
-    <span ng-if="alias != ''">{{alias}}</span>
-    <span ng-if="alias == ''">{{build.name}}</span>
-    <span ng-if="build.date || build.revision">({{build.date | scDateTime}} {{build.revision}})</span>
+
+    <span uib-tooltip="{{build.date | scDateTime}} {{build.revision}}"
+    tooltip-placement="bottom">
+
+        {{name}}:
+        <span ng-if="alias">{{alias}}</span>
+        <span ng-if="!alias">{{build.name}}</span>
+
+    </span>
+
 </h3>


### PR DESCRIPTION
fixes #657: wrong import of comparison screenshot title template
and improves the title by moving date and revision into a tooltip
(less likely to break the layout on small screens and only show important information on screen)

  
  