### PR TITLE
Feature/598 make java8 work using updated elasticsearch

### DIFF
--- a/scenarioo-client/app/build/useCasesTab.html
+++ b/scenarioo-client/app/build/useCasesTab.html
@@ -53,7 +53,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         </td>
                         <td>
                             {{useCase.name | scHumanReadable }}
-                            <span ng-repeat="label in useCase.labels.labels" class="label label-info sc-label" ng-style="useCasesTab.getLabelStyle(label)">{{label}}</span>
+                            <span ng-repeat="label in useCase.labels.label" class="label label-info sc-label" ng-style="useCasesTab.getLabelStyle(label)">{{label}}</span>
                         </td>
                         <td>{{useCase.description}}</td>
                         <td>{{useCase.numberOfScenarios}}</td>

--- a/scenarioo-client/app/scenario/scenario.controller.js
+++ b/scenarioo-client/app/scenario/scenario.controller.js
@@ -91,8 +91,8 @@ function ScenarioController($filter, $routeParams,
 
                 loadRelatedIssues();
 
-                var hasAnyUseCaseLabels = vm.useCase.labels.labels.length > 0;
-                var hasAnyScenarioLabels = vm.scenario.labels.labels.length > 0;
+                var hasAnyUseCaseLabels = vm.useCase.labels.label.length > 0;
+                var hasAnyScenarioLabels = vm.scenario.labels.label.length > 0;
                 vm.hasAnyLabels = hasAnyUseCaseLabels || hasAnyScenarioLabels;
 
                 if (ConfigService.expandPagesInScenarioOverview()) {

--- a/scenarioo-client/app/scenario/scenario.html
+++ b/scenarioo-client/app/scenario/scenario.html
@@ -90,13 +90,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <sc-collapsable-panel title="Labels" key="scenarioView-labels" initially-expanded="false" ng-show="vm.hasAnyLabels">
             <div class="sc-tree">
                 <ul>
-                    <li ng-show="vm.useCase.labels.labels">
+                    <li ng-show="vm.useCase.labels.label">
                         Use case:
-                        <span ng-repeat="label in vm.useCase.labels.labels" class="label label-info sc-label" ng-style="vm.getLabelStyle(label)">{{label}}</span>
+                        <span ng-repeat="label in vm.useCase.labels.label" class="label label-info sc-label" ng-style="vm.getLabelStyle(label)">{{label}}</span>
                     </li>
-                    <li ng-show="vm.scenario.labels.labels">
+                    <li ng-show="vm.scenario.labels.label">
                         Scenario:
-                        <span ng-repeat="label in vm.scenario.labels.labels" class="label label-info sc-label" ng-style="vm.getLabelStyle(label)">{{label}}</span>
+                        <span ng-repeat="label in vm.scenario.labels.label" class="label label-info sc-label" ng-style="vm.getLabelStyle(label)">{{label}}</span>
                     </li>
                 </ul>
             </div>

--- a/scenarioo-client/app/step/step.controller.js
+++ b/scenarioo-client/app/step/step.controller.js
@@ -121,8 +121,8 @@ function StepController($scope, $routeParams, $location, $route, StepResource, S
                 $scope.hasAnyLabels = function () {
                     var hasAnyUseCaseLabels = $scope.useCaseLabels.labels.length > 0;
                     var hasAnyScenarioLabels = $scope.scenarioLabels.labels.length > 0;
-                    var hasAnyStepLabels = $scope.step.stepDescription.labels.labels.length > 0;
-                    var hasAnyPageLabels = $scope.step.page.labels.labels.length > 0;
+                    var hasAnyStepLabels = $scope.step.stepDescription.labels.label.length > 0;
+                    var hasAnyPageLabels = $scope.step.page.labels.label.length > 0;
 
                     return hasAnyUseCaseLabels || hasAnyScenarioLabels || hasAnyStepLabels || hasAnyPageLabels;
                 };
@@ -545,7 +545,7 @@ function StepController($scope, $routeParams, $location, $route, StepResource, S
     var getAllLabels = function () {
         var allLabels = [];
         if ($scope.useCaseLabels && $scope.scenarioLabels && $scope.step) {
-            allLabels = allLabels.concat($scope.useCaseLabels.labels).concat($scope.scenarioLabels.labels).concat($scope.step.stepDescription.labels.labels).concat($scope.step.page.labels.labels);
+            allLabels = allLabels.concat($scope.useCaseLabels.labels).concat($scope.scenarioLabels.labels).concat($scope.step.stepDescription.labels.label).concat($scope.step.page.labels.label);
         }
         return allLabels;
     };

--- a/scenarioo-client/app/step/step.html
+++ b/scenarioo-client/app/step/step.html
@@ -333,14 +333,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         <span ng-repeat="label in scenarioLabels.labels" class="label label-info sc-label"
                               ng-style="getLabelStyle(label)">{{label}}</span>
                     </li>
-                    <li id="step-labels" ng-show="step.stepDescription.labels.labels">
+                    <li id="step-labels" ng-show="step.stepDescription.labels.label">
                         Step:
-                        <span ng-repeat="label in step.stepDescription.labels.labels" class="label label-info sc-label"
+                        <span ng-repeat="label in step.stepDescription.labels.label" class="label label-info sc-label"
                               ng-style="getLabelStyle(label)">{{label}}</span>
                     </li>
-                    <li id="page-labels" ng-show="step.page.labels.labels">
+                    <li id="page-labels" ng-show="step.page.labels.label">
                         Page:
-                        <span ng-repeat="label in step.page.labels.labels" class="label label-info sc-label"
+                        <span ng-repeat="label in step.page.labels.label" class="label label-info sc-label"
                               ng-style="getLabelStyle(label)">{{label}}</span>
                     </li>
                 </ul>

--- a/scenarioo-client/app/useCase/usecase.controller.js
+++ b/scenarioo-client/app/useCase/usecase.controller.js
@@ -123,7 +123,7 @@ function UseCaseController($scope, $filter, $routeParams, $location, ScenarioRes
         vm.useCase = result.useCase;
         vm.usecaseInformationTree = createUseCaseInformationTree(vm.useCase);
         vm.metadataTree = $filter('scMetadataTreeListCreator')(vm.useCase.details);
-        vm.hasAnyLabels = vm.useCase.labels && vm.useCase.labels.labels.length !== 0;
+        vm.hasAnyLabels = vm.useCase.labels && vm.useCase.labels.label.length !== 0;
 
         if(SelectedComparison.isDefined()) {
             var selected = SelectedBranchAndBuildService.selected();

--- a/scenarioo-client/app/useCase/usecase.html
+++ b/scenarioo-client/app/useCase/usecase.html
@@ -60,7 +60,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 </td>
                 <td>
                     {{scenarioSummary.scenario.name | scHumanReadable }}
-                    <span ng-repeat="label in scenarioSummary.scenario.labels.labels" class="label label-info sc-label"
+                    <span ng-repeat="label in scenarioSummary.scenario.labels.label" class="label label-info sc-label"
                           ng-style="useCase.getLabelStyle(label)">{{label}}</span>
                 </td>
                 <td>
@@ -98,7 +98,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <ul>
                     <li>
                         Use case:
-                        <span ng-repeat="label in useCase.useCase.labels.labels" class="label label-info sc-label"
+                        <span ng-repeat="label in useCase.useCase.labels.label" class="label label-info sc-label"
                               ng-style="useCase.getLabelStyle(label)">{{label}}</span>
                     </li>
                 </ul>

--- a/scenarioo-client/test/mock/testData.ts
+++ b/scenarioo-client/test/mock/testData.ts
@@ -177,7 +177,7 @@ angular.module('scenarioo.services').service('TestData', function () {
                 'name': 'Find Page',
                 'labels': {
                     'empty': true,
-                    'labels': []
+                    'label': []
                 }
             },
             'pagesAndSteps': [
@@ -234,7 +234,7 @@ angular.module('scenarioo.services').service('TestData', function () {
                 'name': 'find_page_with_text_on_page_from_multiple_results',
                 'labels': {
                     'empty': true,
-                    'labels': []
+                    'label': []
                 }
             },
             'scenarioStatistics': {
@@ -282,7 +282,7 @@ angular.module('scenarioo.services').service('TestData', function () {
                     'screenshotFileName': '002.png',
                     'index': 2,
                     'labels': {
-                        'labels': ['step-label-0', 'public'],
+                        'label': ['step-label-0', 'public'],
                         'empty': false
                     }
                 },
@@ -314,7 +314,7 @@ angular.module('scenarioo.services').service('TestData', function () {
                     'details': {},
                     'name': 'searchResults.jsp',
                     'labels': {
-                        'labels': ['page-label1', 'page-label2'],
+                        'label': ['page-label1', 'page-label2'],
                         'empty': false
                     }
                 },

--- a/scenarioo-server/src/main/java/org/scenarioo/business/builds/AvailableBuildsList.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/business/builds/AvailableBuildsList.java
@@ -31,7 +31,6 @@ import org.scenarioo.rest.base.BuildIdentifier;
 
 import java.io.File;
 import java.util.*;
-import java.util.function.Predicate;
 
 /**
  * Manages all the currently available builds and maintains aliases to the most recent builds for each branch.
@@ -193,12 +192,7 @@ public class AvailableBuildsList {
 
 	private boolean isBranchAlias(String branchName) {
 		return configurationRepository.getConfiguration().getBranchAliases().stream()
-			.anyMatch(new Predicate<BranchAlias>() {
-				@Override
-				public boolean test(BranchAlias branchAlias) {
-					return branchAlias.getName().equals(branchName);
-				}
-			});
+			.anyMatch(branchAlias -> branchAlias.getName().equals(branchName));
 	}
 
 	private void addImportedBuild(BuildImportSummary buildImportSummary, BranchBuilds branchBuilds) {

--- a/scenarioo-server/src/main/java/org/scenarioo/dao/search/elasticsearch/ElasticSearchAdapter.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/dao/search/elasticsearch/ElasticSearchAdapter.java
@@ -79,6 +79,9 @@ public class ElasticSearchAdapter implements SearchAdapter {
 				.addTransportAddress(new InetSocketTransportAddress(InetAddress.getByName(host), port));
 		} catch (UnknownHostException e) {
 			LOGGER.warn("No elasticsearch cluster running.");
+		} catch (Throwable e) {
+			// Silently log the error in any case to not let Scenarioo crash just because Easticsearch connection fails somehow.
+			LOGGER.error("Could not connect to Elastic Search Engine", e);
 		}
     }
 

--- a/scenarioo-server/src/main/java/org/scenarioo/rest/application/ScenariooRestApplication.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/rest/application/ScenariooRestApplication.java
@@ -1,5 +1,6 @@
 package org.scenarioo.rest.application;
 
+import org.apache.log4j.Logger;
 import org.scenarioo.rest.base.AbstractBuildContentResource;
 import org.scenarioo.rest.base.exceptions.ResourceNotFoundExceptionHandler;
 import org.scenarioo.rest.base.exceptions.RuntimeExceptionHandler;
@@ -30,11 +31,14 @@ import java.util.Set;
 @ApplyRequestLogging
 public class ScenariooRestApplication extends Application {
 
+	private static final Logger LOGGER = Logger.getLogger(ScenariooWebApplication.class);
+
 	private Set<Object> singletons = new HashSet<Object>();
 
 	public ScenariooRestApplication() {
 		// find . -name \*Resource.java
 		//does the order play a role in what order URLs get matched??
+		LOGGER.info("Register Scenarioo REST Services ...");
 		singletons.add(new BranchAliasesResource());
 		singletons.add(new ConfigurationResource());
 		singletons.add(new LabelConfigurationsResource());
@@ -63,6 +67,7 @@ public class ScenariooRestApplication extends Application {
 		// Exception handlers
 		singletons.add(new ResourceNotFoundExceptionHandler());
 		singletons.add(new RuntimeExceptionHandler());
+		LOGGER.info("Register Scenarioo REST Services done.");
 
 	}
 

--- a/scenarioo-server/src/main/java/org/scenarioo/rest/application/ScenariooRestApplication.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/rest/application/ScenariooRestApplication.java
@@ -1,6 +1,8 @@
 package org.scenarioo.rest.application;
 
 import org.scenarioo.rest.base.AbstractBuildContentResource;
+import org.scenarioo.rest.base.exceptions.ResourceNotFoundExceptionHandler;
+import org.scenarioo.rest.base.exceptions.RuntimeExceptionHandler;
 import org.scenarioo.rest.base.logging.ApplyRequestLogging;
 import org.scenarioo.rest.builds.BranchBuildsResource;
 import org.scenarioo.rest.builds.BuildsResource;
@@ -32,6 +34,7 @@ public class ScenariooRestApplication extends Application {
 
 	public ScenariooRestApplication() {
 		// find . -name \*Resource.java
+		//does the order play a role in what order URLs get matched??
 		singletons.add(new BranchAliasesResource());
 		singletons.add(new ConfigurationResource());
 		singletons.add(new LabelConfigurationsResource());
@@ -39,13 +42,13 @@ public class ScenariooRestApplication extends Application {
 		singletons.add(new SketchImageResource());
 		singletons.add(new ScenarioSketchResource());
 		singletons.add(new IssueResource());
-		singletons.add(new ScreenshotResource());
 		singletons.add(new StepResource());
 		singletons.add(new BranchBuildsResource());
 		singletons.add(new BuildsResource());
 		singletons.add(new ComparisonsResource());
 		singletons.add(new SearchResource());
 		singletons.add(new ScenariosResource());
+		singletons.add(new ScreenshotResource());
 		singletons.add(new GenericObjectsResource());
 		singletons.add(new CustomTabsResource());
 		singletons.add(new ObjectStepResource());
@@ -56,7 +59,11 @@ public class ScenariooRestApplication extends Application {
 		singletons.add(new StepDiffInfoResource());
 		singletons.add(new VersionResource());
 		singletons.add(new UseCasesResource());
-		singletons.add(new AbstractBuildContentResource());
+
+		// Exception handlers
+		singletons.add(new ResourceNotFoundExceptionHandler());
+		singletons.add(new RuntimeExceptionHandler());
+
 	}
 
 	@Override

--- a/scenarioo-server/src/main/java/org/scenarioo/rest/base/exceptions/ResourceNotFoundExceptionHandler.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/rest/base/exceptions/ResourceNotFoundExceptionHandler.java
@@ -1,16 +1,16 @@
 /* scenarioo-server
  * Copyright (C) 2014, scenarioo.org Development Team
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -23,17 +23,16 @@ import javax.ws.rs.ext.Provider;
 
 import org.scenarioo.api.exception.ResourceNotFoundException;
 
-
-import com.sun.istack.logging.Logger;
+import org.apache.log4j.Logger;
 
 @Provider
-public class ExceptionHandler implements ExceptionMapper<ResourceNotFoundException> {
-	
-	private Logger LOGGER = Logger.getLogger(ExceptionHandler.class);
-	
+public class ResourceNotFoundExceptionHandler implements ExceptionMapper<ResourceNotFoundException> {
+
+	private Logger LOGGER = Logger.getLogger(ResourceNotFoundExceptionHandler.class);
+
 	@Override
 	public Response toResponse(final ResourceNotFoundException exception) {
-		LOGGER.info("Resource not found", exception);
-		return Response.status(500).build();
+		LOGGER.error("Resource not found", exception);
+		return Response.status(404).build();
 	}
 }

--- a/scenarioo-server/src/main/java/org/scenarioo/rest/base/exceptions/RuntimeExceptionHandler.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/rest/base/exceptions/RuntimeExceptionHandler.java
@@ -1,0 +1,23 @@
+package org.scenarioo.rest.base.exceptions;
+
+import org.apache.log4j.Logger;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * This exception handler is very important to have error logs in case of runtime errors (=potential bugs)
+ */
+@Provider
+public class RuntimeExceptionHandler implements ExceptionMapper<RuntimeException> {
+
+	private Logger LOGGER = Logger.getLogger(ResourceNotFoundExceptionHandler.class);
+
+	@Override
+	public Response toResponse(final RuntimeException exception) {
+		LOGGER.error("Runtime exception", exception);
+		return Response.status(500).build();
+	}
+}

--- a/scenarioo-server/src/main/java/org/scenarioo/rest/diffViewer/BuildDiffInfoResource.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/rest/diffViewer/BuildDiffInfoResource.java
@@ -30,7 +30,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import java.util.List;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 @Path("/rest/diffViewer/baseBranchName/{baseBranchName}/baseBuildName/{baseBuildName}")
@@ -65,11 +64,8 @@ public class BuildDiffInfoResource {
 		return diffReader
 			.loadBuildDiffInfos(buildIdentifier.getBranchName(), buildIdentifier.getBuildName())
 			.stream()
-			.filter(new Predicate<BuildDiffInfo>() {
-				@Override
-				public boolean test(BuildDiffInfo buildDiffInfo) {
-					return ComparisonCalculationStatus.SUCCESS.equals(buildDiffInfo.getComparisonCalculationStatus());
-				}
-			}).collect(Collectors.toList());
+			.filter(buildDiffInfo ->
+				ComparisonCalculationStatus.SUCCESS.equals(buildDiffInfo.getComparisonCalculationStatus())
+			).collect(Collectors.toList());
 	}
 }

--- a/scenarioo-server/src/main/java/org/scenarioo/rest/scenario/ScenariosResource.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/rest/scenario/ScenariosResource.java
@@ -1,16 +1,16 @@
 /* scenarioo-server
  * Copyright (C) 2014, scenarioo.org Development Team
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -36,40 +36,41 @@ import org.scenarioo.rest.scenario.mapper.ScenarioDetailsMapper;
 
 @Path("/rest/branch/{branchName}/build/{buildName}/usecase/{usecaseName}/scenario/")
 public class ScenariosResource {
-	
+
 	private final ConfigurationRepository configurationRepository = RepositoryLocator.INSTANCE
 			.getConfigurationRepository();
-	
+
 	private final AggregatedDocuDataReader aggregatedDataReader = new ScenarioDocuAggregationDao(
 			configurationRepository.getDocumentationDataDirectory());
-	
+
 	private final ScenarioDetailsMapper scenarioDetailsMapper = new ScenarioDetailsMapper();
-	
+
 	@GET
 	@Produces({ "application/xml", "application/json" })
+	@Path("")
 	public UseCaseScenarios readUseCaseScenarios(@PathParam("branchName") final String branchName,
 			@PathParam("buildName") final String buildName, @PathParam("usecaseName") final String usecaseName) {
-		
+
 		BuildIdentifier buildIdentifier = ScenarioDocuBuildsManager.INSTANCE.resolveBranchAndBuildAliases(branchName,
 				buildName);
-		
+
 		return aggregatedDataReader.loadUseCaseScenarios(buildIdentifier, usecaseName);
 	}
-	
+
 	@GET
 	@Produces({ "application/xml", "application/json" })
-	@Path("{scenarioName}/")
+	@Path("{scenarioName}")
 	public ScenarioDetails readScenarioWithPagesAndSteps(@PathParam("branchName") final String branchName,
 			@PathParam("buildName") final String buildName, @PathParam("usecaseName") final String usecaseName,
 			@PathParam("scenarioName") final String scenarioName) {
-		
+
 		BuildIdentifier buildIdentifier = ScenarioDocuBuildsManager.INSTANCE.resolveBranchAndBuildAliases(branchName,
 				buildName);
 		ScenarioIdentifier scenarioIdentifier = new ScenarioIdentifier(buildIdentifier, usecaseName, scenarioName);
-		
+
 		ScenarioPageSteps pageSteps = aggregatedDataReader.loadScenarioPageSteps(scenarioIdentifier);
-		
+
 		return scenarioDetailsMapper.map(pageSteps);
 	}
-	
+
 }

--- a/scenarioo-server/src/main/java/org/scenarioo/rest/step/ScreenshotResource.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/rest/step/ScreenshotResource.java
@@ -1,16 +1,16 @@
 /* scenarioo-server
  * Copyright (C) 2014, scenarioo.org Development Team
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -40,12 +40,12 @@ import org.scenarioo.rest.step.logic.StepIndexResolver;
 import org.scenarioo.rest.step.logic.StepLoader;
 import org.scenarioo.rest.step.logic.StepLoaderResult;
 
-@Path("/rest/branch/{branchName}/build/{buildName}/usecase/{usecaseName}/scenario/{scenarioName}/")
+@Path("/rest/branch/{branchName}/build/{buildName}/usecase/{usecaseName}/scenario/")
 public class ScreenshotResource {
-	
+
 	private final ConfigurationRepository configurationRepository = RepositoryLocator.INSTANCE
 			.getConfigurationRepository();
-	
+
 	private final LongObjectNamesResolver longObjectNamesResolver = new LongObjectNamesResolver();
 	private final AggregatedDocuDataReader aggregatedDataReader = new ScenarioDocuAggregationDao(
 			configurationRepository.getDocumentationDataDirectory(), longObjectNamesResolver);
@@ -54,48 +54,48 @@ public class ScreenshotResource {
 	private final StepLoader stepImageInfoLoader = new StepLoader(scenarioLoader, stepIndexResolver);
 	private final ScreenshotResponseFactory screenshotResponseFactory = new ScreenshotResponseFactory();
 	private final LabelsQueryParamParser labelsQueryParamParser = new LabelsQueryParamParser();
-	
+
 	/**
 	 * This method is used internally for loading the image of a step. It is the faster method, because it already knows
 	 * the filename of the image.
 	 */
 	@GET
 	@Produces("image/jpeg")
-	@Path("image/{imageFileName}")
+	@Path("{scenarioName}/image/{imageFileName}")
 	public Response getScreenshot(@PathParam("branchName") final String branchName,
 			@PathParam("buildName") final String buildName, @PathParam("usecaseName") final String usecaseName,
 			@PathParam("scenarioName") final String scenarioName, @PathParam("imageFileName") final String imageFileName) {
-		
+
 		BuildIdentifier buildIdentifier = ScenarioDocuBuildsManager.INSTANCE.resolveBranchAndBuildAliases(branchName,
 				buildName);
 		ScenarioIdentifier scenarioIdentifier = new ScenarioIdentifier(buildIdentifier, usecaseName, scenarioName);
-		
+
 		return screenshotResponseFactory.createFoundImageResponse(scenarioIdentifier, imageFileName, false);
 	}
-	
+
 	/**
 	 * This method is used for sharing screenshot images. It is a bit slower, because the image filename has to be
 	 * resolved first. But it is also more stable, because it uses the new "stable" URL pattern.
 	 */
 	@GET
 	@Produces("image/jpeg")
-	@Path("pageName/{pageName}/pageOccurrence/{pageOccurrence}/stepInPageOccurrence/{stepInPageOccurrence}/image.{extension}")
+	@Path("{scenarioName}/pageName/{pageName}/pageOccurrence/{pageOccurrence}/stepInPageOccurrence/{stepInPageOccurrence}/image.{extension}")
 	public Response getScreenshotStable(@PathParam("branchName") final String branchName,
 			@PathParam("buildName") final String buildName, @PathParam("usecaseName") final String usecaseName,
 			@PathParam("scenarioName") final String scenarioName, @PathParam("pageName") final String pageName,
 			@PathParam("pageOccurrence") final int pageOccurrence,
 			@PathParam("stepInPageOccurrence") final int stepInPageOccurrence,
 			@QueryParam("fallback") final boolean fallback, @QueryParam("labels") final String labels) {
-		
+
 		BuildIdentifier buildIdentifierBeforeAliasResolution = new BuildIdentifier(branchName, buildName);
 		BuildIdentifier buildIdentifier = ScenarioDocuBuildsManager.INSTANCE.resolveBranchAndBuildAliases(branchName,
 				buildName);
 		StepIdentifier stepIdentifier = new StepIdentifier(buildIdentifier, usecaseName, scenarioName, pageName,
 				pageOccurrence, stepInPageOccurrence, labelsQueryParamParser.parseLabels(labels));
-		
+
 		StepLoaderResult stepImageInfo = stepImageInfoLoader.loadStep(stepIdentifier);
-		
+
 		return screenshotResponseFactory.createResponse(stepImageInfo, fallback, buildIdentifierBeforeAliasResolution);
 	}
-	
+
 }


### PR DESCRIPTION
@cgrossde @eggerschwiler related to #598 and #616 

In this PR you can see what I did so far to get it working with RestEasy 3.
The merge goes to your branch #685 - not to develop yet - such that you can review my changes and profit from my improvements.

Auf diesem Branch sind jetzt nur noch 16 Tests gefailed. Ich vermute noch aus drei Gründen:

1. RestEasy Path Konflikte: neue Version interpretiert @Path teilweise anders ---> man sollte jetzt im Server Log entsprechende Fehlermeldungen sehen (dank den hinzugefügten ExceptionHandlern).

2. Teilweise werden Collections in RestEasy 3 anders serialisiert, wenn sie nur mit @XmlElement annotiert wurden --> z.B. "labels" (ev. ausschliesslich?) kommen anders im Frontend an, gewisse Tests failen deshalb, ich habe das partiell gefixt. Hier ist zu überlegen ob wir die `scenarioo-java` fixen wollen (Achtung: Xml-Format darf nicht gebrochen werden!) oder den angefangenen Weg (im Frontend anpassen) weiterführen wollen.

3. Fehlender Elasticsearch 5 Cluster mit Name "elasticsearch" auf CI --> Full Text Search e2e tests gebrochen.
