### PR TITLE
#673 Configure Comparisons with regexp for all feature branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,15 @@ This file lists the changes in newer versions of scenarioo.
 
 Improvements to the Diff Viewer:
 
-* [#602 - Removed Dependency to GraphicMagick](https://github.com/scenarioo/scenarioo/issues/602): GraphicMagick needs not to be installed anymore to use the DiffViewer feature.
-* [#618 - New DiffViewer Internal Diff Screen Format](https://github.com/scenarioo/scenarioo/issues/618) The comparison builds need now less disk space because only a difference image per screenshot is stored. Needs reimport of builds to see comparisons again, see [Migration Guide](docs/setup/Migration-Guide.md).
-* [#597 - Store diff information directly inside build](https://github.com/scenarioo/scenarioo/issues/597): Also the comparisons are stored now inside the belonging build directories, such that the diffs get automatically cleaned up when deleting a build. Breaking change, see [Migration Guide](docs/setup/Migration-Guide.md).
+* [#650 - Manage Comparisons View](https://github.com/scenarioo/scenarioo/issues/650): To see all calculated comparisons, their error logs and have the ability to trigger a comparison for recalculation if needed.
+* [#692 - Create Comparison Manually through the Web Frontend](https://github.com/scenarioo/scenarioo/issues/692): user can create a comparison through a modal dialog.
 * [#603 - Improved Comparison View](https://github.com/scenarioo/scenarioo/issues/603) to understand the comparison of two screenshots and the possible comparison view options better. Also highlighting of changes is now available in both screenshots.
 * [#596 - Configure Highlight Color for Changes in DiffViewer Comparison Screenshots](https://github.com/scenarioo/scenarioo/issues/596): new config property `diffImageColorRgbaHex` to customize the highlight color.
+* [#673 - Comparison Configurations with Regexp for base branches to compare](https://github.com/scenarioo/scenarioo/issues/673): allow to define comparisons against another build to be calculated on multiple branches selected by regexp (e.g. for all feature branches)
+* [#604 - Background Calculation of Comparisons](https://github.com/scenarioo/scenarioo/issues/604): to not block builds from being imported while a comparison is computed.
+* [#597 - Store diff information directly inside build](https://github.com/scenarioo/scenarioo/issues/597): Also the comparisons are stored now inside the belonging build directories, such that the diffs get automatically cleaned up when deleting a build. Breaking change, see [Migration Guide](docs/setup/Migration-Guide.md).
+* [#602 - Removed Dependency to GraphicMagick](https://github.com/scenarioo/scenarioo/issues/602): GraphicMagick needs not to be installed anymore to use the DiffViewer feature.
+* [#618 - New DiffViewer Internal Diff Screen Format](https://github.com/scenarioo/scenarioo/issues/618) The comparison builds need now less disk space because only a difference image per screenshot is stored. Needs reimport of builds to see comparisons again, see [Migration Guide](docs/setup/Migration-Guide.md).
 * [#577 - Avoid Null Pointer Exceptions](https://github.com/scenarioo/scenarioo/issues/577): Do not log null pointer exceptions when there is just no step to compare too.
 
 ### Features "Small Improvements & Fixes"

--- a/build-java.gradle
+++ b/build-java.gradle
@@ -14,6 +14,7 @@ dependencies {
     compile 'commons-codec:commons-codec:1.10'
     compile 'log4j:log4j:1.2.17'
     testCompile 'junit:junit:4.12'
+    testCompile 'org.assertj:assertj-core:3.10.0'
 }
 
 sourceCompatibility = '1.8'

--- a/scenarioo-docu-generation-example/src/test/resources/config-for-demo/config.xml
+++ b/scenarioo-docu-generation-example/src/test/resources/config-for-demo/config.xml
@@ -59,7 +59,7 @@
 	<comparisonConfigurations>
         <comparisonConfiguration>
             <name>To Develop</name>
-            <baseBranchName>scenarioo-feature-*</baseBranchName>
+            <baseBranchName>scenarioo-feature-.*</baseBranchName>
             <comparisonBranchName>scenarioo-develop</comparisonBranchName>
             <comparisonBuildName>last successful</comparisonBuildName>
         </comparisonConfiguration>

--- a/scenarioo-docu-generation-example/src/test/resources/config-for-demo/config.xml
+++ b/scenarioo-docu-generation-example/src/test/resources/config-for-demo/config.xml
@@ -58,6 +58,18 @@
     </branchAliases>
 	<comparisonConfigurations>
         <comparisonConfiguration>
+            <name>To Develop</name>
+            <baseBranchName>scenarioo-feature-*</baseBranchName>
+            <comparisonBranchName>scenarioo-develop</comparisonBranchName>
+            <comparisonBuildName>last successful</comparisonBuildName>
+        </comparisonConfiguration>
+        <comparisonConfiguration>
+            <name>To Last Release</name>
+            <baseBranchName>scenarioo-develop</baseBranchName>
+            <comparisonBranchName>scenarioo-master</comparisonBranchName>
+            <comparisonBuildName>last successful</comparisonBuildName>
+        </comparisonConfiguration>
+        <comparisonConfiguration>
             <name>To last successful</name>
             <baseBranchName>wikipedia-docu-example-dev</baseBranchName>
             <comparisonBranchName>wikipedia-docu-example</comparisonBranchName>
@@ -71,13 +83,7 @@
         </comparisonConfiguration>
 		<comparisonConfiguration>
             <name>To Projectstart</name>
-            <baseBranchName>wikipedia-docu-example-dev</baseBranchName>
-            <comparisonBranchName>Production</comparisonBranchName>
-            <comparisonBuildName>2014-01-20</comparisonBuildName>
-        </comparisonConfiguration>
-		<comparisonConfiguration>
-            <name>To Projectstart</name>
-            <baseBranchName>wikipedia-docu-example</baseBranchName>
+            <baseBranchName>wikipedia-docu-.*</baseBranchName>
             <comparisonBranchName>Production</comparisonBranchName>
             <comparisonBuildName>2014-01-20</comparisonBuildName>
         </comparisonConfiguration>

--- a/scenarioo-server/src/main/java/org/scenarioo/business/diffViewer/ComparisonExecutor.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/business/diffViewer/ComparisonExecutor.java
@@ -336,7 +336,8 @@ public class ComparisonExecutor {
 		String resolvedBaseBranchName = aliasResolver.resolveBranchAlias(baseBranchName);
 		for (ComparisonConfiguration comparisonConfiguration : comparisonConfigurations) {
 			String resolvedComparisonBranchName = aliasResolver.resolveBranchAlias(comparisonConfiguration.getBaseBranchName());
-			if (resolvedBaseBranchName.equals(resolvedComparisonBranchName)) {
+			if (resolvedBaseBranchName.equals(resolvedComparisonBranchName)
+				|| resolvedBaseBranchName.matches(resolvedComparisonBranchName)) {
 				comparisonConfigurationsForBaseBranch.add(comparisonConfiguration);
 			}
 		}

--- a/scenarioo-server/src/main/java/org/scenarioo/business/diffViewer/ComparisonExecutor.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/business/diffViewer/ComparisonExecutor.java
@@ -127,12 +127,7 @@ public class ComparisonExecutor {
 		LOGGER.info("Scheduling Comparison of build for background calculation: \n"
 			+ "     " + getComparisonConfigString(baseBranchName, baseBuildName, comparisonConfiguration));
 
-		Future<BuildDiffInfo> futureComparison = asyncComparisonExecutor.submit(new Callable<BuildDiffInfo>() {
-			@Override
-			public BuildDiffInfo call() {
-				return calculateComparison(baseBranchName, baseBuildName, comparisonConfiguration);
-			}
-		});
+		Future<BuildDiffInfo> futureComparison = asyncComparisonExecutor.submit(() -> calculateComparison(baseBranchName, baseBuildName, comparisonConfiguration));
 
 		ComparisonParameters comparisonParameters = new ComparisonParameters(baseBranchName, baseBuildName, comparisonConfiguration,
 			configurationRepository.getConfiguration().getDiffImageAwtColor());
@@ -241,16 +236,15 @@ public class ComparisonExecutor {
 		return logAppender;
 	}
 
-	private BuildDiffInfo storeAndLogComparisonSkipped(ComparisonParameters comparisonParameters) {
+	private void storeAndLogComparisonSkipped(ComparisonParameters comparisonParameters) {
 		LOGGER.warn("No comparison build found for base build: " + comparisonParameters.getBaseBranchName()
 			+ "/" + comparisonParameters.getBaseBuildName()
 			+ " with defined comparison: " + comparisonParameters.getComparisonConfiguration().getName());
-		BuildDiffInfo buildDiffInfo = saveBuildDiffInfoWithStatus(comparisonParameters, ComparisonCalculationStatus.SKIPPED);
+		saveBuildDiffInfoWithStatus(comparisonParameters, ComparisonCalculationStatus.SKIPPED);
 		LOGGER.info("SKIPPED comparing base build: " + comparisonParameters.getBaseBranchName()
 			+ "/" + comparisonParameters.getBaseBuildName()
 			+ " with defined comparison: " + comparisonParameters.getComparisonConfiguration().getName());
 		LOGGER.info("=== END OF BUILD COMPARISON (skipped) ===");
-		return buildDiffInfo;
 	}
 
 	private void storeComparisonAsProcessing(ComparisonParameters comparisonParameters) {
@@ -357,21 +351,21 @@ public class ComparisonExecutor {
 		String lastSuccessFulAlias = configurationRepository.getConfiguration().getAliasForLastSuccessfulBuild();
 		String mostRecentAlias = configurationRepository.getConfiguration().getAliasForMostRecentBuild();
 
+		String baseBranchName = this.aliasResolver.resolveBranchAlias(comparisonConfiguration.getBaseBranchName());
+		String comparisonBranchName = this.aliasResolver.resolveBranchAlias(comparisonConfiguration.getComparisonBranchName());
+		boolean isBuildsFromSameBranch = baseBranchName.equals(comparisonBranchName);
+		boolean isComparisonToLastSuccessBuild = comparisonConfiguration.getComparisonBuildName().equals(lastSuccessFulAlias);
+		boolean isComparisonToMostRecentBuild = comparisonConfiguration.getComparisonBuildName().equals(mostRecentAlias);
+		boolean isComparisonToBuildAlias = isComparisonToLastSuccessBuild ||isComparisonToMostRecentBuild;
+
 		BuildIdentifier comparisonBuildIdentifier;
 
-		if (comparisonConfiguration.getComparisonBuildName().equals(lastSuccessFulAlias) &&
-			comparisonConfiguration.getBaseBranchName().equals(comparisonConfiguration.getComparisonBranchName())) {
-
+		if 	(isBuildsFromSameBranch && isComparisonToBuildAlias) {
+			// In this case we have to interpret the aliases "last succesful" or "most recent" relative to current build.
 			comparisonBuildIdentifier = getPreviousBuildIdentifier(
-				comparisonConfiguration, baseBuildName, true);
-
-		} else if (comparisonConfiguration.getComparisonBuildName().equals(mostRecentAlias) &&
-			comparisonConfiguration.getBaseBranchName().equals(comparisonConfiguration.getComparisonBranchName())) {
-
-			comparisonBuildIdentifier = getPreviousBuildIdentifier(
-				comparisonConfiguration, baseBuildName, false);
-
+					comparisonConfiguration, baseBuildName, isComparisonToLastSuccessBuild);
 		} else {
+			// Otherwise simply resolve with usual alias resolving to current defined aliases
 			comparisonBuildIdentifier = this.aliasResolver.resolveBranchAndBuildAliases(
 				comparisonConfiguration.getComparisonBranchName(),
 				comparisonConfiguration.getComparisonBuildName());

--- a/scenarioo-server/src/main/java/org/scenarioo/business/diffViewer/ComparisonExecutor.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/business/diffViewer/ComparisonExecutor.java
@@ -327,8 +327,7 @@ public class ComparisonExecutor {
 	/**
 	 * Reads the reloaded xml configuration and returns all comparison configurations for the given base branch.
 	 */
-	synchronized List<ComparisonConfiguration> getComparisonConfigurationsForBaseBranch(
-		String baseBranchName) {
+	synchronized List<ComparisonConfiguration> getComparisonConfigurationsForBaseBranch(String baseBranchName) {
 		List<ComparisonConfiguration> comparisonConfigurationsForBaseBranch = new LinkedList<>();
 
 		List<ComparisonConfiguration> comparisonConfigurations = configurationRepository.getConfiguration()
@@ -338,7 +337,7 @@ public class ComparisonExecutor {
 			String resolvedComparisonBranchName = aliasResolver.resolveBranchAlias(comparisonConfiguration.getBaseBranchName());
 			if (resolvedBaseBranchName.equals(resolvedComparisonBranchName)
 				|| resolvedBaseBranchName.matches(resolvedComparisonBranchName)) {
-				comparisonConfigurationsForBaseBranch.add(comparisonConfiguration);
+				comparisonConfigurationsForBaseBranch.add(new ComparisonConfiguration(comparisonConfiguration, baseBranchName));
 			}
 		}
 		return comparisonConfigurationsForBaseBranch;

--- a/scenarioo-server/src/main/java/org/scenarioo/business/diffViewer/ComparisonExecutor.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/business/diffViewer/ComparisonExecutor.java
@@ -334,10 +334,10 @@ public class ComparisonExecutor {
 			.getComparisonConfigurations();
 		String resolvedBaseBranchName = aliasResolver.resolveBranchAlias(baseBranchName);
 		for (ComparisonConfiguration comparisonConfiguration : comparisonConfigurations) {
-			String resolvedComparisonBranchName = aliasResolver.resolveBranchAlias(comparisonConfiguration.getBaseBranchName());
-			if (resolvedBaseBranchName.equals(resolvedComparisonBranchName)
-				|| resolvedBaseBranchName.matches(resolvedComparisonBranchName)) {
-				comparisonConfigurationsForBaseBranch.add(new ComparisonConfiguration(comparisonConfiguration, baseBranchName));
+			String resolvedConfigurationBaseBranchName = aliasResolver.resolveBranchAlias(comparisonConfiguration.getBaseBranchName());
+			if (resolvedBaseBranchName.equals(resolvedConfigurationBaseBranchName)
+				|| resolvedBaseBranchName.matches(resolvedConfigurationBaseBranchName)) {
+				comparisonConfigurationsForBaseBranch.add(new ComparisonConfiguration(comparisonConfiguration, resolvedBaseBranchName));
 			}
 		}
 		return comparisonConfigurationsForBaseBranch;

--- a/scenarioo-server/src/main/java/org/scenarioo/model/configuration/ComparisonConfiguration.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/model/configuration/ComparisonConfiguration.java
@@ -1,16 +1,16 @@
 /* scenarioo-server
  * Copyright (C) 2014, scenarioo.org Development Team
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -29,6 +29,16 @@ public class ComparisonConfiguration {
 	private String baseBranchName;
 	private String comparisonBranchName;
 	private String comparisonBuildName;
+
+	public ComparisonConfiguration() {
+	}
+
+	public ComparisonConfiguration(ComparisonConfiguration config, String matchingBaseBranchName) {
+		this.name = config.name;
+		this.baseBranchName = matchingBaseBranchName;
+		this.comparisonBranchName = config.comparisonBranchName;
+		this.comparisonBuildName = config.comparisonBuildName;
+	}
 
 	public String getName() {
 		return name;


### PR DESCRIPTION
Fixes #673 

Now we can use regexp in comparison configurations like "feature/.*" to compare all feature branches against e.g. "develop".

I configured for our self docu to always compare feature branches against develop on every new build.

