### PR TITLE
CI Pipeline: also lock tomcat for e2e tests to not execute tests in parallel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,7 +98,7 @@ timestamps {
             ansiColor('xterm') {
 
                 try {
-                    lock("tomcat") {
+                    lock("tomcat") { // no parallel deployments to tomcat
                         withCredentials([usernameColonPassword(credentialsId: 'SCENARIOO_TOMCAT', variable: 'TOMCAT_USERPASS')]) {
                             sh "./ci/deploy.sh --branch=${encodedBranchName}"
                             def demoUrl = "http://demo.scenarioo.org/scenarioo-${encodedBranchName}"
@@ -125,7 +125,9 @@ timestamps {
             ansiColor('xterm') {
 
                 try {
-                         sh "./ci/runE2ETests.sh --branch=${encodedBranchName}"
+                    lock("tomcat") { // no parallel e2e test executions against tomcat
+                        sh "./ci/runE2ETests.sh --branch=${encodedBranchName}"
+                    }
                 } finally {
                     junit 'scenarioo-client/test-reports/*.xml'
                     withCredentials([usernameColonPassword(credentialsId: 'SCENARIOO_TOMCAT', variable: 'TOMCAT_USERPASS')]) {


### PR DESCRIPTION
with other deployments or other e2e tests against same tomcat (in other parallel build jobs)

@adiherzog maybe for now better to reduce troubles when we work in parallel.