### PR TITLE
#720 Selfdocu: Compare master and develop on same demo

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -40,7 +40,7 @@ BRANCH_DATA_ARCHIVE_DIR=/var/lib/scenarioo/data-archive/$BRANCH
 echo "Undeploy Old Scenarioo Web App"
 curl -u $TOMCAT_USERPASS http://localhost:8080/manager/text/undeploy\?path\=/scenarioo-$BRANCH
 
-# Backup all self docu and other important example docu reports to be restored after succesful deployment and testing of this scenarioo instance
+# Backup all self docu and other important example docu reports to be restored after successful deployment and testing of this scenarioo instance
 mkdir -p $BRANCH_DATA_ARCHIVE_DIR
 cp -rfp $BRANCH_DATA_DIR/scenarioo-* $BRANCH_DATA_ARCHIVE_DIR
 cp -rfp $BRANCH_DATA_DIR/pizza-* $BRANCH_DATA_ARCHIVE_DIR

--- a/ci/deploySelfDocu.sh
+++ b/ci/deploySelfDocu.sh
@@ -28,25 +28,25 @@ SCENARIOO_DATA_ROOT=/var/lib/scenarioo/data
 SCENARIOO_DATA_BRANCH_DIR=$SCENARIOO_DATA_ROOT/$BRANCH
 SCENARIOO_DATA_BRANCH_ARCHIVE_DIR=/var/lib/scenarioo/data-archive/$BRANCH
 
-# Decide to which scenarioo instance to deploy the self-docu:
-if [ $BRANCH = "master" ]
-then
-    # Only master self docu is deployed to master demo to also have one scenarioo self-docu visible on master demo
-    SCENARIOO_DATA_SELF_DOCU_DIR=$SCENARIOO_DATA_ROOT/master
-else
-    # Feature branches and develop branch are only reported to develop demo of scenarioo
-    SCENARIOO_DATA_SELF_DOCU_DIR=$SCENARIOO_DATA_ROOT/develop
-fi
+# Deploy self docu to develop demo (and for important branches only also to master demo):
+SCENARIOO_DATA_SELF_DOCU_DIR=$SCENARIOO_DATA_ROOT/develop
+SCENARIOO_DATA_SELF_DOCU_MASTER_DIR=$SCENARIOO_DATA_ROOT/master
 
 # Restore all archived documentation data to be reatained for this branch (was archived in deploy.sh before deploying)
 # (this is needed to not loose all self docu builds on develop deployment or pizza-delivery and other examples)
+# [additional remark: the `|| true` is needed here to not let it fail if there was no archived data to be copied (e.g. for new feature branches without archived builds)]
 echo "Restoring Documentation Data: Self Docu and Examples"
-cp -rp $SCENARIOO_DATA_BRANCH_ARCHIVE_DIR/* $SCENARIOO_DATA_BRANCH_DIR
-rm -rf $SCENARIOO_DATA_BRANCH_ARCHIVE_DIR
+cp -rp $SCENARIOO_DATA_BRANCH_ARCHIVE_DIR/* $SCENARIOO_DATA_BRANCH_DIR || true
+rm -rf $SCENARIOO_DATA_BRANCH_ARCHIVE_DIR || true
 
 # Deploy generated self docu of this build run
 echo "Deploy the generated self docu build to $SCENARIOO_DATA_SELF_DOCU_DIR"
 cp -rf ./scenarioo-client/scenariooDocumentation/* $SCENARIOO_DATA_SELF_DOCU_DIR
+if [ $BRANCH = "master" ] || [ $BRANCH = "develop" ]
+then
+    echo "Deploy the generated self docu build to $SCENARIOO_DATA_SELF_DOCU_MASTER_DIR"
+    cp -rf ./scenarioo-client/scenariooDocumentation/* $SCENARIOO_DATA_SELF_DOCU_MASTER_DIR
+fi
 rm -rf ./scenarioo-client/scenariooDocumentation
 
 # Do the cleanup of all directories and all data and deployments

--- a/scenarioo-client/package-lock.json
+++ b/scenarioo-client/package-lock.json
@@ -49,7 +49,7 @@
         "@types/selenium-webdriver": {
             "version": "2.53.43",
             "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-2.53.43.tgz",
-            "integrity": "sha1-LePXGIGbwgFldUxKWa+36YM/Zwc=",
+            "integrity": "sha512-UBYHWph6P3tutkbXpW6XYg9ZPbTKjw/YC2hGG1/GEvWwTbvezBUv3h+mmUFw79T3RFPnmedpiXdOBbXX+4l0jg==",
             "dev": true
         },
         "accepts": {
@@ -241,7 +241,7 @@
         "anymatch": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-            "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
+            "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
             "dev": true,
             "requires": {
                 "micromatch": "2.3.11",
@@ -269,7 +269,7 @@
         "arr-flatten": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-            "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
             "dev": true
         },
         "array-flatten": {
@@ -502,7 +502,7 @@
         "bluebird": {
             "version": "3.5.1",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-            "integrity": "sha1-2VUfnemPH82h5oPRfukaBgLuLrk=",
+            "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
             "dev": true
         },
         "bn.js": {
@@ -853,7 +853,7 @@
         "circular-json": {
             "version": "0.3.3",
             "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-            "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
+            "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
             "dev": true
         },
         "clap": {
@@ -1204,7 +1204,7 @@
         "content-type": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-            "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js=",
+            "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
             "dev": true
         },
         "cookie": {
@@ -3171,7 +3171,7 @@
         "glob": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-            "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "dev": true,
             "requires": {
                 "fs.realpath": "1.0.0",
@@ -3736,7 +3736,7 @@
         "ini": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-            "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
+            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
             "dev": true
         },
         "inquirer": {
@@ -3849,7 +3849,7 @@
         "is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
             "dev": true
         },
         "is-builtin-module": {
@@ -4759,7 +4759,7 @@
         "minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
                 "brace-expansion": "1.1.8"
@@ -4924,7 +4924,7 @@
         "normalize-package-data": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-            "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+            "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
             "dev": true,
             "requires": {
                 "hosted-git-info": "2.5.0",
@@ -5963,7 +5963,7 @@
         "promise": {
             "version": "7.3.1",
             "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-            "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
+            "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
             "dev": true,
             "optional": true,
             "requires": {
@@ -6313,7 +6313,7 @@
         "regex-cache": {
             "version": "0.4.4",
             "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-            "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
+            "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "dev": true,
             "requires": {
                 "is-equal-shallow": "0.1.3"
@@ -6541,7 +6541,7 @@
         "rimraf": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-            "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "dev": true,
             "requires": {
                 "glob": "7.1.2"
@@ -7092,7 +7092,7 @@
         "source-map-support": {
             "version": "0.4.18",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-            "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
+            "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
             "dev": true,
             "requires": {
                 "source-map": "0.5.7"
@@ -8419,7 +8419,7 @@
         "websocket-extensions": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-            "integrity": "sha1-XS/yKXcAPsaHpLhwc9+7rBRszyk=",
+            "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
             "dev": true
         },
         "whet.extend": {
@@ -8431,7 +8431,7 @@
         "which": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-            "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
+            "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
             "dev": true,
             "requires": {
                 "isexe": "2.0.0"


### PR DESCRIPTION
Fixes #720 

Deploy self docu of master and develop always to both: master and develop demo instances.

This can also help to see whether our new version is backward compatible for old docu data from master branch or whether we introduced backwards compatible problems on master demo.

One open point: 
Does it make sense to deploy both to both our master as well as our develop instance?
* Pro: 
     1. We can also demo in the master demo for latest release, how it looks if two real builds are compared. 
     2. People can see in our master demo the newest upcoming features of scenarioo
     3. This can be tested on master demo, because on develop the master docu will still be missing until we merge that change to master (or we have to fix it once manually by copying the master branch to the develop demo)

* Contra: The new docu from the develop instance might become breaking (once we do breaking changes to the scenarioo format, which happens rarely and only for special releases) and not work on the master instance, We might have to disable that in such cases later again. 

I went for the 3 pro arguments outweighing the disadvantage that it might lead to failing imports on the master demo (which by the way is not that bad - would not fail our tests, since those do not test our self docu deployments)

@adiherzog what do you think?