### PR TITLE
Remove strange options from docker docu

### DIFF
--- a/docs/tutorial/Scenarioo-Viewer-Docker-Image.md
+++ b/docs/tutorial/Scenarioo-Viewer-Docker-Image.md
@@ -14,7 +14,7 @@ How to set up and run the Scenarioo Viewer Web App as a docker image:
 
 1. Simply run the following one liner command to install and run the docker image:
     ```
-    sudo docker run -it --rm --name scenarioo -p 8080:8080 -v /home/user/your-scenarioo-docu-folder:/scenarioo/data scenarioo/webapp:4.0.0
+    sudo docker run -it --name scenarioo -p 8080:8080 -v /home/user/your-scenarioo-docu-folder:/scenarioo/data scenarioo/webapp:4.0.0
     ```
     with following parameters:    
     * `--name` - defines a name for the container (= running image)  


### PR DESCRIPTION
I think we should not use docker options in our docu, that are not really needed to run our image - Users can decide on their own, what options they need if they want to tweak behaviour - the default is to keep the container.