### PR TITLE
Feature/797 malicious string error

### DIFF
--- a/scenarioo-server/src/main/java/org/scenarioo/ScenariooViewerApplication.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/ScenariooViewerApplication.java
@@ -10,6 +10,8 @@ import org.springframework.boot.web.servlet.ServletContextInitializer;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.web.firewall.HttpFirewall;
+import org.springframework.security.web.firewall.StrictHttpFirewall;
 import org.springframework.web.multipart.commons.CommonsMultipartResolver;
 import org.springframework.web.servlet.config.annotation.*;
 
@@ -71,5 +73,12 @@ public class ScenariooViewerApplication extends SpringBootServletInitializer imp
 	@Override
 	public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
 		configurer.favorPathExtension(false);
+	}
+
+	@Bean
+	public HttpFirewall allowUrlEncodedPercentHttpFirewall() {
+		StrictHttpFirewall firewall = new StrictHttpFirewall();
+		firewall.setAllowUrlEncodedPercent(true);
+		return firewall;
 	}
 }

--- a/scenarioo-server/src/main/java/org/scenarioo/ScenariooViewerApplication.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/ScenariooViewerApplication.java
@@ -75,6 +75,11 @@ public class ScenariooViewerApplication extends SpringBootServletInitializer imp
 		configurer.favorPathExtension(false);
 	}
 
+	/**
+	 * Spring Boot uses the StrictHttpFirewall. By default it blocks requests containing URL encoded percent signs.
+	 * In the Scenarioo End to End Tests this occurs in the scenario "Use breadcrumbs > Tooltip in breadcrumbs".
+	 * If this feature is not disabled then an Internal Server Error is shown to the user.
+	 */
 	@Bean
 	public HttpFirewall allowUrlEncodedPercentHttpFirewall() {
 		StrictHttpFirewall firewall = new StrictHttpFirewall();


### PR DESCRIPTION
Problem: 
Spring Boot uses a StrictHttpFirewall which blocks encoded percentage signs in urls. If a request is sent with such an encoded percentage sign (i.e. %25) then an Internal Server Error is returned.
In the Scenarioo End to End Tests this occurs in the scenario "Use breadcrumbs > Tooltip in breadcrumbs".

Steps to reproduce:
1. Go to http://demo.scenarioo.org/scenarioo-develop/#/scenario/Use%20breadcrumbs/Tooltip%20in%20breadcrumbs?branch=scenarioo-develop&build=last%20successful&comparison=Disabled
2. Click on Step 1

Solution:
The Firewall can be configured and this feature disabled.

Steps to verify:
1. Go to http://demo.scenarioo.org/scenarioo-feature-797-malicious-String-error/?#/scenario/Use%20breadcrumbs/Tooltip%20in%20breadcrumbs?branch=scenarioo-feature-797-malicious-String-error&build=last%20successful&comparison=Disabled&tab=usecases
2. Click on Step 1

fixes #797 