### PR TITLE
#815: pass correct values to recalculate function.

### DIFF
--- a/scenarioo-client/app/manage/comparisons/comparisons.controller.ts
+++ b/scenarioo-client/app/manage/comparisons/comparisons.controller.ts
@@ -68,8 +68,8 @@ function ComparisonsController($scope, $uibModal, $route, ComparisonsResource, C
     function recalculateComparison(comparison) {
         ComparisonRecalculateResource
             .recalculate(comparison.name, {
-                branchName: comparison.baseBuild,
-                buildName: comparison.baseBuild,
+                branchName: comparison.baseBuild.branchName,
+                buildName: comparison.baseBuild.buildName,
             })
             .subscribe(refresh);
     }


### PR DESCRIPTION
Bugfix. The wrong parameters were passed to recalculate function, which led to a 404 response from the server when recalculate comparison was called in the UI.

fixes #815 