### PR TITLE
Feature/814 manage builds broken

### DIFF
--- a/scenarioo-client/app/manage/buildImport/buildsList.controller.ts
+++ b/scenarioo-client/app/manage/buildImport/buildsList.controller.ts
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import {tap} from "rxjs/operators";
+import {tap} from 'rxjs/operators';
 
 declare var angular: angular.IAngularStatic;
 

--- a/scenarioo-client/app/manage/buildImport/buildsList.controller.ts
+++ b/scenarioo-client/app/manage/buildImport/buildsList.controller.ts
@@ -14,6 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import {tap} from "rxjs/operators";
+
 declare var angular: angular.IAngularStatic;
 
 angular.module('scenarioo.controllers').controller('BuildsListController', BuildsListController);
@@ -76,7 +78,7 @@ function BuildsListController($scope, $route, $uibModal, BuildImportStatesResour
     function reimportBuild(build) {
         vm.updatingBuildsInProgress = true;
         BuildReimportResource.get(build.identifier.branchName, build.identifier.buildName)
-            .tap(() => vm.updatingBuildsInProgress = false)
+            .pipe(tap(() => vm.updatingBuildsInProgress = false))
             .subscribe(buildImportFinished);
     }
 
@@ -92,7 +94,7 @@ function BuildsListController($scope, $route, $uibModal, BuildImportStatesResour
     function importAndUpdateBuilds() {
         vm.updatingBuildsInProgress = true;
         BuildImportService.updateData()
-            .tap(() => vm.updatingBuildsInProgress = false)
+            .pipe(tap(() => vm.updatingBuildsInProgress = false))
             .subscribe(buildImportFinished);
     }
 

--- a/scenarioo-client/app/shared/services/buildImport.service.ts
+++ b/scenarioo-client/app/shared/services/buildImport.service.ts
@@ -14,7 +14,7 @@ export class BuildImportService {
     }
 
     updateData(): Observable<any> {
-        return this.httpClient.get(this.url);
+        return this.httpClient.get(this.url, {responseType: 'text'});
     }
 }
 

--- a/scenarioo-client/app/shared/services/buildReimportResource.service.ts
+++ b/scenarioo-client/app/shared/services/buildReimportResource.service.ts
@@ -13,7 +13,7 @@ export class BuildReimportResource {
 
     get(branchName: string, buildName: string): Observable<any> {
         // Returns just OK or NOT_FOUND.
-        return this.httpClient.get(`rest/builds/${branchName}/${buildName}/import`);
+        return this.httpClient.get(`rest/builds/${branchName}/${buildName}/import`, {responseType: 'text'});
     }
 }
 


### PR DESCRIPTION
The tap() function was used to update a flag which kept the information whether a build update is in progress. However, tap() is not a function of httpClient but of rxjs. So it needed to be called inside a pipe() call.

A follow up problem was that httpClient expects a JSON result. For void calls this led to a parsing error. Setting the expected responseType to 'text' solved this issue.

fixes #814 