### PR TITLE
Feature/819 step with space not found

### DIFF
--- a/scenarioo-server/src/main/java/org/scenarioo/rest/base/StepIdentifier.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/rest/base/StepIdentifier.java
@@ -15,6 +15,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.scenarioo.dao.context.ContextPathHolder;
+import org.scenarioo.utils.UrlEncoding;
 
 /**
  * Contains all the properties needed to identify a step unambiguously.
@@ -63,10 +64,19 @@ public class StepIdentifier {
 	public StepIdentifier(final ScenarioIdentifier scenarioIdentifier, final String pageName, final int pageOccurrence,
 			final int stepInPageOccurrence, final Set<String> labels) {
 		this.scenarioIdentifier = scenarioIdentifier;
-		this.pageName = pageName;
+		this.pageName = patchPageName(pageName);
 		this.pageOccurrence = pageOccurrence;
 		this.stepInPageOccurrence = stepInPageOccurrence;
 		this.labels = labels;
+	}
+
+	/**
+	 * Spring Boot automatically decodes all request parameters. This is a problem if a pageName should contain for example
+	 * an URL encoded space. Thus we need to patch the page name in this case. And since the default URL encoding replaces
+	 * a space with '+', we have to manually replace this with '%20'.
+	 */
+	private String patchPageName(String pageName) {
+		return pageName.contains(" ") ? UrlEncoding.encode(pageName).replace("+", "%20") : pageName;
 	}
 
 	public static StepIdentifier withDifferentStepInPageOccurrence(final StepIdentifier stepIdentifier,

--- a/scenarioo-server/src/main/java/org/scenarioo/rest/base/StepIdentifier.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/rest/base/StepIdentifier.java
@@ -64,7 +64,7 @@ public class StepIdentifier {
 	public StepIdentifier(final ScenarioIdentifier scenarioIdentifier, final String pageName, final int pageOccurrence,
 			final int stepInPageOccurrence, final Set<String> labels) {
 		this.scenarioIdentifier = scenarioIdentifier;
-		this.pageName = patchPageName(pageName);
+		this.setPageName(pageName);
 		this.pageOccurrence = pageOccurrence;
 		this.stepInPageOccurrence = stepInPageOccurrence;
 		this.labels = labels;
@@ -162,7 +162,7 @@ public class StepIdentifier {
 	}
 
 	public void setPageName(final String pageName) {
-		this.pageName = pageName;
+		this.pageName = patchPageName(pageName);
 	}
 
 	public int getPageOccurrence() {

--- a/scenarioo-server/src/test/java/org/scenarioo/rest/base/StepIdentifierTest.java
+++ b/scenarioo-server/src/test/java/org/scenarioo/rest/base/StepIdentifierTest.java
@@ -57,4 +57,25 @@ public class StepIdentifierTest {
 		}
 	}
 
+	@Test
+	public void patchPageNameForPageNameWithSpaceInConstructor() {
+		//act
+		StepIdentifier testee = new StepIdentifier(scenarioIdentifier, "page name", 0, 1);
+
+		//assert
+		assertEquals("page%20name", testee.getPageName());
+	}
+
+	@Test
+	public void patchPageNameForPageNameWithSpaceInSetter() {
+		//arrange
+		StepIdentifier testee = new StepIdentifier(scenarioIdentifier, "pagename", 0, 1);
+
+		//act
+		testee.setPageName("page name");
+
+		//assert
+		assertEquals("page%20name", testee.getPageName());
+	}
+
 }


### PR DESCRIPTION
In the E2E Test Usecase "Browse page variants" and Scenario "Browse variants" the step details can not be displayed. If one of the steps is clicked then a "The step you are looking for does not exist" error occurs.

First analysis shows that it is a problem with the encoding of the space.

The rest service receives the following String as pageName: "step_Switch Language_search_article_in_german_and_switch_to_spanish_contentPage.jsp_0_2"
Internally we have the following String linked to this Step: "step_Switch%20Language_search_article_in_german_and_switch_to_spanish_contentPage.jsp_0_2"

To reproduce visit this demo page and click on any of the pages.

Workaround solution: In StepIdentifier we use URL encoding to ensure we have no unencoded values which cause problems. Unfortunately, URLEncoder replaces a space with a '+', thus we then have to manually replace the '+' with '%20'

fixes #819 