### PR TITLE
Feature/727 build import ui issues

### DIFF
--- a/scenarioo-client/app/manage/buildImport/buildsList.html
+++ b/scenarioo-client/app/manage/buildImport/buildsList.html
@@ -58,12 +58,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <td>{{build.buildDescription.date | scDateTime}}</td>
                 <td>{{build.buildDescription.revision}}</td>
                 <td>
-                    {{ build.buildStatistics.numberOfSuccessfulUseCases + build.buildStatistics.numberOfFailedUseCases }}
-                    <span ng-show="build.buildStatistics.numberOfFailedUseCases != 0">({{ build.buildStatistics.numberOfFailedUseCases }} failed)</span>
+                    <span ng-show="build.status != 'PROCESSING'">
+                        {{ build.buildStatistics.numberOfSuccessfulUseCases + build.buildStatistics.numberOfFailedUseCases }}
+                        <span ng-show="build.buildStatistics.numberOfFailedUseCases != 0">({{ build.buildStatistics.numberOfFailedUseCases }} failed)</span>
+                    </span>
                 </td>
                 <td>
-                    {{ build.buildStatistics.numberOfSuccessfulScenarios + build.buildStatistics.numberOfFailedScenarios }}
-                    <span ng-show="build.buildStatistics.numberOfFailedScenarios != 0">({{ build.buildStatistics.numberOfFailedScenarios }} failed)</span>
+                    <span ng-show="build.status != 'PROCESSING'">
+                        {{ build.buildStatistics.numberOfSuccessfulScenarios + build.buildStatistics.numberOfFailedScenarios }}
+                        <span ng-show="build.buildStatistics.numberOfFailedScenarios != 0">({{ build.buildStatistics.numberOfFailedScenarios }} failed)</span>
+                    </span>
                 </td>
                 <td>
                     <span ng-class="[getStatusStyleClass(build.buildDescription.status), 'label']">{{build.buildDescription.status}}</span>

--- a/scenarioo-server/src/main/java/org/scenarioo/business/builds/BuildImporter.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/business/builds/BuildImporter.java
@@ -192,6 +192,7 @@ public class BuildImporter {
 
 		availableBuilds.removeBuild(buildIdentifier);
 		summary.setStatus(BuildImportStatus.UNPROCESSED);
+		summary.setStatusMessage(null);
 		ScenarioDocuAggregator aggregator = new ScenarioDocuAggregator(summary);
 		aggregator.removeAggregatedDataForBuild();
 


### PR DESCRIPTION
fixes #727 

Fixed two UI-Issues:

1. Import message was not cleared when reimport was triggered. Solution: Also reset the statusMessage in the BuildSummary when a reimport is triggered.
2. Do not show scenarios and use case numbers while Reimport is in progress. Solution: Add ng-show, which only displays the numbers when the import status is not PROGRESSING.