### PR TITLE
#886 show error details in case of StepNotFound.

### DIFF
--- a/scenarioo-client/app/step/step.controller.ts
+++ b/scenarioo-client/app/step/step.controller.ts
@@ -141,7 +141,7 @@ function StepController($scope, $routeParams, $location, $route, StepResource, S
                     $scope.stepNotFound = true;
                     $scope.httpResponse = {
                         status: error.status,
-                        method: "GET",
+                        method: 'GET',
                         url: error.url,
                         data: error.error,
                     };

--- a/scenarioo-client/app/step/step.controller.ts
+++ b/scenarioo-client/app/step/step.controller.ts
@@ -141,9 +141,9 @@ function StepController($scope, $routeParams, $location, $route, StepResource, S
                     $scope.stepNotFound = true;
                     $scope.httpResponse = {
                         status: error.status,
-                        method: error.config.method,
-                        url: error.config.url,
-                        data: error.data,
+                        method: "GET",
+                        url: error.url,
+                        data: error.error,
                     };
                 },
             );

--- a/scenarioo-client/app/step/step.html
+++ b/scenarioo-client/app/step/step.html
@@ -22,8 +22,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <div class="sc-alert-title">The step you are looking for does not exist</div>
         <p>URL: {{getCurrentUrl()}}</p>
         <p>REST URL to get step: {{httpResponse.url}}</p>
-        <p>HTTP method: {{httpResponse.method}}</p>
-        <p>HTTP response status: {{httpResponse.status}}</p>
+        <p>HTTP method: <span id="stepNotFoundErrorResponseMethod">{{httpResponse.method}}</span></p>
+        <p>HTTP response status: <span id="stepNotFoundErrorResponseStatus">{{httpResponse.status}}</span></p>
         <p>Response data: {{httpResponse.data}}</p>
     </div>
 </div>

--- a/scenarioo-client/test/e2e/pages/stepPage.ts
+++ b/scenarioo-client/test/e2e/pages/stepPage.ts
@@ -75,8 +75,8 @@ class StepPage {
     }
 
     async assertErrorResponseIsShown() {
-        await expect(element(by.id('stepNotFoundErrorResponseMethod')).getText()).toEqual("GET");
-        await expect(element(by.id('stepNotFoundErrorResponseStatus')).getText()).toEqual("404");
+        await expect(element(by.id('stepNotFoundErrorResponseMethod')).getText()).toEqual('GET');
+        await expect(element(by.id('stepNotFoundErrorResponseStatus')).getText()).toEqual('404');
     }
 
     async assertFallbackMessageIsShown() {

--- a/scenarioo-client/test/e2e/pages/stepPage.ts
+++ b/scenarioo-client/test/e2e/pages/stepPage.ts
@@ -74,6 +74,11 @@ class StepPage {
         await expect(element(by.id('fallbackMessage')).isDisplayed()).toBeFalsy();
     }
 
+    async assertErrorResponseIsShown() {
+        await expect(element(by.id('stepNotFoundErrorResponseMethod')).getText()).toEqual("GET");
+        await expect(element(by.id('stepNotFoundErrorResponseStatus')).getText()).toEqual("404");
+    }
+
     async assertFallbackMessageIsShown() {
         await expect(element(by.id('fallbackMessage')).isDisplayed()).toBeTruthy();
         return expect(element(by.id('stepNotFoundErrorMessage')).isDisplayed()).toBeFalsy();

--- a/scenarioo-client/test/e2e/pages/stepPage.ts
+++ b/scenarioo-client/test/e2e/pages/stepPage.ts
@@ -74,9 +74,9 @@ class StepPage {
         await expect(element(by.id('fallbackMessage')).isDisplayed()).toBeFalsy();
     }
 
-    async assertErrorResponseIsShown() {
-        await expect(element(by.id('stepNotFoundErrorResponseMethod')).getText()).toEqual('GET');
-        await expect(element(by.id('stepNotFoundErrorResponseStatus')).getText()).toEqual('404');
+    async assertErrorResponseIsShown(expectedResponseMethod: string, expectedResponseStatus: string) {
+        await expect(element(by.id('stepNotFoundErrorResponseMethod')).getText()).toEqual(expectedResponseMethod);
+        await expect(element(by.id('stepNotFoundErrorResponseStatus')).getText()).toEqual(expectedResponseStatus);
     }
 
     async assertFallbackMessageIsShown() {

--- a/scenarioo-client/test/e2e/specs/step_view.ts
+++ b/scenarioo-client/test/e2e/specs/step_view.ts
@@ -72,6 +72,7 @@ useCase('Step - View')
             .it(async () => {
                 await Utils.navigateToRoute('/step/Find Page/find_no_results/inexistent_page.jsp/0/42');
                 await StepPage.assertErrorMessageIsShown();
+                await StepPage.assertErrorResponseIsShown();
                 await step('Error message.');
             });
 

--- a/scenarioo-client/test/e2e/specs/step_view.ts
+++ b/scenarioo-client/test/e2e/specs/step_view.ts
@@ -72,7 +72,7 @@ useCase('Step - View')
             .it(async () => {
                 await Utils.navigateToRoute('/step/Find Page/find_no_results/inexistent_page.jsp/0/42');
                 await StepPage.assertErrorMessageIsShown();
-                await StepPage.assertErrorResponseIsShown();
+                await StepPage.assertErrorResponseIsShown('GET', '404');
                 await step('Error message.');
             });
 

--- a/scenarioo-client/test/spec/step/step.controller.spec.ts
+++ b/scenarioo-client/test/spec/step/step.controller.spec.ts
@@ -307,10 +307,7 @@ describe('StepController', () => {
             $httpBackend.whenGET('rest/branch/trunk/build/current/usecase/uc/scenario/sc').respond(TestData.SCENARIO);
             spyOn(StepResourceMock, 'get').and.returnValue(observableThrowError({
                 status: 500,
-                config: {
-                    method: "GET",
-                    url: 'rest/branch/trunk/build/current/usecase/uc/scenario/sc/pageName/pn/pageOccurrence/0/stepInPageOccurrence/42'
-                }
+                url: 'rest/branch/trunk/build/current/usecase/uc/scenario/sc/pageName/pn/pageOccurrence/0/stepInPageOccurrence/42'
             }));
 
             ConfigService.load();


### PR DESCRIPTION
fixes #886 

On the Step Not Found page the error details were not displayed correctly because the error object of HttpClient had changed.