### PR TITLE
Feature/889 application startup bug

### DIFF
--- a/scenarioo-client/app/app.ts
+++ b/scenarioo-client/app/app.ts
@@ -48,7 +48,9 @@ angular.module('scenarioo', ['scenarioo.controllers', 'ui.bootstrap', 'scenarioo
     });
 
     $rootScope.$on('$viewContentLoaded', () => {
-        ApplicationInfoPopupService.showApplicationInfoPopupIfRequired();
+        // Workaround because angular reloads the page a couple of times if query parameter were not set, which leads
+        // to a reload of all controllers and a dismissal of the open PopUp. Thus it disappears very quickly.
+        setTimeout(() => ApplicationInfoPopupService.showApplicationInfoPopupIfRequired(), 50);
     });
 
     // Register global hotkeys

--- a/scenarioo-client/app/services/configuration.service.ts
+++ b/scenarioo-client/app/services/configuration.service.ts
@@ -53,7 +53,7 @@ export class ConfigurationService {
     }
 
     defaultBranchAndBuild() {
-        if(this._config == undefined) {
+        if (this._config === undefined) {
             return {
                 branch: undefined,
                 build: undefined,

--- a/scenarioo-client/app/services/configuration.service.ts
+++ b/scenarioo-client/app/services/configuration.service.ts
@@ -16,9 +16,9 @@ export class ConfigurationService {
     private _config: IConfiguration;
 
     private updateConfigurationSubject = (configuration) => {
-        this.configuration.next(configuration);
         this._config = configuration;
-    }
+        this.configuration.next(configuration);
+    };
 
     constructor(private configResource: ConfigResource) {
     }

--- a/scenarioo-client/app/services/configuration.service.ts
+++ b/scenarioo-client/app/services/configuration.service.ts
@@ -18,7 +18,7 @@ export class ConfigurationService {
     private updateConfigurationSubject = (configuration) => {
         this._config = configuration;
         this.configuration.next(configuration);
-    };
+    }
 
     constructor(private configResource: ConfigResource) {
     }

--- a/scenarioo-client/app/services/configuration.service.ts
+++ b/scenarioo-client/app/services/configuration.service.ts
@@ -53,6 +53,12 @@ export class ConfigurationService {
     }
 
     defaultBranchAndBuild() {
+        if(this._config == undefined) {
+            return {
+                branch: undefined,
+                build: undefined,
+            };
+        }
         return {
             branch: this._config.defaultBranchName,
             build: this._config.defaultBuildName,


### PR DESCRIPTION
Timing issues cause the startup problems.

1.) ConfigurationService.defaultBranchAndBuild() is accessed before this._config is set.
2.) If the page is accessed without query parameters, then the application info popup is shown but immediately dismissed because the page is reloaded when the query parameters are updated. Since the popup was "shown" once, it will not be shown again.

Solutions:
1.) return undefined if this._config is not yet set
2.) Delay call to ApplicationInfoPopUp (needs to be fixed during Angular migration)