### PR TITLE
#892 let spring choose correct content-type

### DIFF
--- a/scenarioo-client/app/step/step.controller.ts
+++ b/scenarioo-client/app/step/step.controller.ts
@@ -515,8 +515,8 @@ function StepController($scope, $routeParams, $location, $route, StepResource, S
             return undefined;
         }
 
-        return getUrlPartBeforeHash($location.absUrl()) + 'rest/branch/' + SelectedBranchAndBuildService.selected()[SelectedBranchAndBuildService.BRANCH_KEY] +
-            '/build/' + SelectedBranchAndBuildService.selected()[SelectedBranchAndBuildService.BUILD_KEY] +
+        return getUrlPartBeforeHash($location.absUrl()) + 'rest/branch/' + encodeURIComponent(SelectedBranchAndBuildService.selected()[SelectedBranchAndBuildService.BRANCH_KEY]) +
+            '/build/' + encodeURIComponent(SelectedBranchAndBuildService.selected()[SelectedBranchAndBuildService.BUILD_KEY]) +
             '/usecase/' + encodeURIComponent(useCaseName) +
             '/scenario/' + encodeURIComponent(scenarioName) +
             '/pageName/' + encodeURIComponent($scope.pageName) +

--- a/scenarioo-client/test/e2e/specs/step_view.ts
+++ b/scenarioo-client/test/e2e/specs/step_view.ts
@@ -109,7 +109,7 @@ useCase('Step - View')
                     '/0/0?comparison=Disabled&branch=wikipedia-docu-example&build=last%20successful' +
                     '&labels=normal-case,step-label-0,public,page-label1,page-label2');
                 await StepPage.assertScreenshotLink(baseUrl  + '/rest/branch/wikipedia-docu-example/build' +
-                    '/last successful/usecase/Find%20Page/scenario/find_no_results/pageName/startSearch.jsp' +
+                    '/last%20successful/usecase/Find%20Page/scenario/find_no_results/pageName/startSearch.jsp' +
                     '/pageOccurrence/0/stepInPageOccurrence/0/image.png' +
                     '?labels=normal-case,step-label-0,public,page-label1,page-label2');
                 await step('Step links dialog.');

--- a/scenarioo-server/src/main/java/org/scenarioo/dao/sketcher/SketcherDao.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/dao/sketcher/SketcherDao.java
@@ -129,12 +129,12 @@ public class SketcherDao {
 	}
 
 	/**
-	 * @param pngFilename
+	 * @param imageFilename
 	 *            Specify whether you want to load the original PNG file or the sketch PNG file.
 	 */
-	public File getStepSketchPngFile(final String branchName, final String issueId, final String scenarioSketchId,
-			final String stepSketchId, final String pngFilename) {
-		return new File(getStepSketchDirectory(branchName, issueId, scenarioSketchId, stepSketchId), pngFilename);
+	public File getStepSketchImageFile(final String branchName, final String issueId, final String scenarioSketchId,
+									   final String stepSketchId, final String imageFilename) {
+		return new File(getStepSketchDirectory(branchName, issueId, scenarioSketchId, stepSketchId), imageFilename);
 	}
 
 	public List<File> getStepSketchFiles(final String branchName, final String issueId,
@@ -187,7 +187,7 @@ public class SketcherDao {
 	 */
 	private void storePngFile(final String branchName, final String issueId, final String scenarioSketchId,
 			final String stepSketchId, final String svgString) {
-		File pngFile = getStepSketchPngFile(branchName, issueId, scenarioSketchId, stepSketchId,
+		File pngFile = getStepSketchImageFile(branchName, issueId, scenarioSketchId, stepSketchId,
 				SKETCH_PNG_FILENAME);
 
 		try {

--- a/scenarioo-server/src/main/java/org/scenarioo/rest/sketcher/stepSketch/SketchImageResource.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/rest/sketcher/stepSketch/SketchImageResource.java
@@ -46,17 +46,17 @@ public class SketchImageResource {
 	}
 
 	/**
-	 * @param pngFileName
+	 * @param imageFileName
 	 *            Specify whether you want to load the original PNG file or the sketch PNG file.
 	 */
-	@GetMapping(path = "{stepSketchId}/image/{pngFile}", produces = "image/png" )
-	public ResponseEntity<InputStreamResource> loadPngFile(@PathVariable("branchName") final String branchName,
-														   @PathVariable("issueId") final String issueId,
-														   @PathVariable("scenarioSketchId") final String scenarioSketchId,
-														   @PathVariable("stepSketchId") final String stepSketchId,
-														   @PathVariable("pngFile") final String pngFileName) {
+	@GetMapping(path = "{stepSketchId}/image/{imageFile}", produces = "image/*" )
+	public ResponseEntity<InputStreamResource> loadImageFile(@PathVariable("branchName") final String branchName,
+															 @PathVariable("issueId") final String issueId,
+															 @PathVariable("scenarioSketchId") final String scenarioSketchId,
+															 @PathVariable("stepSketchId") final String stepSketchId,
+															 @PathVariable("imageFile") final String imageFileName) {
 		String resolvedBranchName = new BranchAliasResolver().resolveBranchAlias(branchName);
-		File pngFile = sketcherDao.getStepSketchPngFile(resolvedBranchName, issueId, scenarioSketchId, stepSketchId, pngFileName);
+		File pngFile = sketcherDao.getStepSketchImageFile(resolvedBranchName, issueId, scenarioSketchId, stepSketchId, imageFileName);
 		return FileResponseCreator.createUncacheableImageFileResponse(pngFile);
 	}
 

--- a/scenarioo-server/src/main/java/org/scenarioo/rest/step/ScreenshotResource.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/rest/step/ScreenshotResource.java
@@ -50,7 +50,7 @@ public class ScreenshotResource {
 	 * This method is used internally for loading the image of a step. It is the faster method, because it already knows
 	 * the filename of the image.
 	 */
-	@GetMapping(path = "{scenarioName}/image/{imageFileName}", produces = "image/jpeg")
+	@GetMapping(path = "{scenarioName}/image/{imageFileName}", produces = "image/*")
 	public ResponseEntity getScreenshot(@PathVariable("branchName") final String branchName,
 			@PathVariable("buildName") final String buildName, @PathVariable("usecaseName") final String usecaseName,
 			@PathVariable("scenarioName") final String scenarioName, @PathVariable("imageFileName") final String imageFileName) {
@@ -66,19 +66,39 @@ public class ScreenshotResource {
 	 * This method is used for sharing screenshot images. It is a bit slower, because the image filename has to be
 	 * resolved first. But it is also more stable, because it uses the new "stable" URL pattern.
 	 */
-	@GetMapping(path = "{scenarioName}/pageName/{pageName}/pageOccurrence/{pageOccurrence}/stepInPageOccurrence/{stepInPageOccurrence}/image.{extension}", produces = "image/jpeg")
-	public ResponseEntity getScreenshotStable(@PathVariable("branchName") final String branchName,
+	@GetMapping(path = "{scenarioName}/pageName/{pageName}/pageOccurrence/{pageOccurrence}/stepInPageOccurrence/{stepInPageOccurrence}/image.png", produces = "image/png")
+	public ResponseEntity getScreenshotStablePng(@PathVariable("branchName") final String branchName,
 											  @PathVariable("buildName") final String buildName, @PathVariable("usecaseName") final String usecaseName,
 											  @PathVariable("scenarioName") final String scenarioName, @PathVariable("pageName") final String pageName,
 											  @PathVariable("pageOccurrence") final int pageOccurrence,
 											  @PathVariable("stepInPageOccurrence") final int stepInPageOccurrence,
 											  @RequestParam(value="fallback", required = false) final boolean fallback, @RequestParam(value="labels", required = false) final String labels) {
 
+		return getScreenshotStable(branchName, buildName, usecaseName, scenarioName, pageName, pageOccurrence, stepInPageOccurrence, fallback, labels);
+	}
+
+	/**
+	 * This method is used for sharing screenshot images. It is a bit slower, because the image filename has to be
+	 * resolved first. But it is also more stable, because it uses the new "stable" URL pattern.
+	 * Additional method with produces=image/jpg is needed, as firefox is a bit picky in its accept headers, so produces image/* does not work.
+	 */
+	@GetMapping(path = "{scenarioName}/pageName/{pageName}/pageOccurrence/{pageOccurrence}/stepInPageOccurrence/{stepInPageOccurrence}/image.{extension}", produces = "image/jpg")
+	public ResponseEntity getScreenshotStableJpg(@PathVariable("branchName") final String branchName,
+											  @PathVariable("buildName") final String buildName, @PathVariable("usecaseName") final String usecaseName,
+											  @PathVariable("scenarioName") final String scenarioName, @PathVariable("pageName") final String pageName,
+											  @PathVariable("pageOccurrence") final int pageOccurrence,
+											  @PathVariable("stepInPageOccurrence") final int stepInPageOccurrence,
+											  @RequestParam(value="fallback", required = false) final boolean fallback, @RequestParam(value="labels", required = false) final String labels) {
+
+		return getScreenshotStable(branchName, buildName, usecaseName, scenarioName, pageName, pageOccurrence, stepInPageOccurrence, fallback, labels);
+	}
+
+	private ResponseEntity getScreenshotStable(@PathVariable("branchName") String branchName, @PathVariable("buildName") String buildName, @PathVariable("usecaseName") String usecaseName, @PathVariable("scenarioName") String scenarioName, @PathVariable("pageName") String pageName, @PathVariable("pageOccurrence") int pageOccurrence, @PathVariable("stepInPageOccurrence") int stepInPageOccurrence, @RequestParam(value = "fallback", required = false) boolean fallback, @RequestParam(value = "labels", required = false) String labels) {
 		BuildIdentifier buildIdentifierBeforeAliasResolution = new BuildIdentifier(branchName, buildName);
 		BuildIdentifier buildIdentifier = ScenarioDocuBuildsManager.getInstance().resolveBranchAndBuildAliases(branchName,
-				buildName);
+			buildName);
 		StepIdentifier stepIdentifier = new StepIdentifier(buildIdentifier, usecaseName, scenarioName, pageName,
-				pageOccurrence, stepInPageOccurrence, labelsQueryParamParser.parseLabels(labels));
+			pageOccurrence, stepInPageOccurrence, labelsQueryParamParser.parseLabels(labels));
 
 		StepLoaderResult stepImageInfo = stepImageInfoLoader.loadStep(stepIdentifier);
 

--- a/scenarioo-server/src/main/java/org/scenarioo/rest/step/ScreenshotResource.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/rest/step/ScreenshotResource.java
@@ -93,7 +93,7 @@ public class ScreenshotResource {
 		return getScreenshotStable(branchName, buildName, usecaseName, scenarioName, pageName, pageOccurrence, stepInPageOccurrence, fallback, labels);
 	}
 
-	private ResponseEntity getScreenshotStable(@PathVariable("branchName") String branchName, @PathVariable("buildName") String buildName, @PathVariable("usecaseName") String usecaseName, @PathVariable("scenarioName") String scenarioName, @PathVariable("pageName") String pageName, @PathVariable("pageOccurrence") int pageOccurrence, @PathVariable("stepInPageOccurrence") int stepInPageOccurrence, @RequestParam(value = "fallback", required = false) boolean fallback, @RequestParam(value = "labels", required = false) String labels) {
+	private ResponseEntity getScreenshotStable(String branchName, String buildName, String usecaseName, String scenarioName, String pageName, int pageOccurrence, int stepInPageOccurrence, boolean fallback, String labels) {
 		BuildIdentifier buildIdentifierBeforeAliasResolution = new BuildIdentifier(branchName, buildName);
 		BuildIdentifier buildIdentifier = ScenarioDocuBuildsManager.getInstance().resolveBranchAndBuildAliases(branchName,
 			buildName);

--- a/scenarioo-server/src/test/java/org/scenarioo/dao/sketcher/SketcherDaoTest.java
+++ b/scenarioo-server/src/test/java/org/scenarioo/dao/sketcher/SketcherDaoTest.java
@@ -97,7 +97,7 @@ public class SketcherDaoTest {
 	}
 
 	private void expectSketchAsPngPersisted() {
-		File pngFile = sketcherDao.getStepSketchPngFile(BRANCH_NAME, ISSUE_ID, SCENARIO_SKETCH_ID,
+		File pngFile = sketcherDao.getStepSketchImageFile(BRANCH_NAME, ISSUE_ID, SCENARIO_SKETCH_ID,
 				STEP_SKETCH.getStepSketchId(), "sketch.png");
 		assertTrue(pngFile.exists());
 	}


### PR DESCRIPTION
let spring choose correct content-type depending on specified accept headers to fix broken images in IE11

Additional fix for ScreenshotResource.getScreenshotStable method is required, as firefox sends accept headers that spring can not handle properly with produces=image/*

fixes #892 