### PR TITLE
Bugfix/895 share sketch

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ For more details, please refer to the [Migration Guide](Migration-Guide.md)
 
 * [#727 - Build Import: UI issues](https://github.com/scenarioo/scenarioo/issues/727): Information displayed while a build is being imported was improved.
 * [#717 - Diff Viewer: Styling and UI issues](https://github.com/scenarioo/scenarioo/issues/717): Various usability improvements. 
+* [#895 - Share this page Screenshot link broken for Sketch](https://github.com/scenarioo/scenarioo/issues/895): The share this page dialog shows the correct image link again when sharing sketches.
 
 ## Version 4.0.1
 

--- a/scenarioo-client/app/sketcher/stepSketch.controller.js
+++ b/scenarioo-client/app/sketcher/stepSketch.controller.js
@@ -89,8 +89,12 @@ function StepSketchController($scope, $routeParams, $location, SelectedBranchAnd
 
         var selected = SelectedBranchAndBuildService.selected();
 
-        return 'rest/branch/' + selected.branch + '/issue/' + issueId + '/scenariosketch/' + scenarioSketchId + '/stepsketch/' + stepSketchId + '/image/sketch.png';
+        return getUrlPartBeforeHash($location.absUrl()) + 'rest/branch/' + encodeURIComponent(selected.branch) + '/issue/' + issueId + '/scenariosketch/' + scenarioSketchId + '/stepsketch/' + stepSketchId + '/image/sketch.png';
     };
+
+    function getUrlPartBeforeHash(url) {
+        return url.split('#')[0];
+    }
 
     function getSketchScreenshotUrl() {
         if (angular.isUndefined(vm.stepSketch)) {


### PR DESCRIPTION
The share this page dialog showed incomplete image links when sharing Sketches

fixes #895 