### PR TITLE
#877 Rest Service providing information if Imports or Comparisons are currently being processed

### DIFF
--- a/scenarioo-server/src/main/java/org/scenarioo/business/builds/BuildImporter.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/business/builds/BuildImporter.java
@@ -77,7 +77,7 @@ public class BuildImporter {
 	/**
 	 * Executor to execute one import task after the other asynchronously.
 	 */
-	private final ExecutorService asyncBuildImportExecutor = newAsyncBuildImportExecutor();
+	private final ThreadPoolExecutor asyncBuildImportExecutor = newAsyncBuildImportExecutor();
 
 	private ComparisonExecutor comparisonExecutor = new ComparisonExecutor(new LazyAliasResolver());
 
@@ -201,6 +201,14 @@ public class BuildImporter {
 	public BuildImportStatus getBuildImportStatus(BuildIdentifier buildIdentifier) {
 		BuildImportSummary buildImportSummary = buildImportSummaries.get(buildIdentifier);
 		return buildImportSummary != null ? buildImportSummary.getStatus() : null;
+	}
+
+	/**
+	 * @return <code>true</code> if no builds are being imported by asyncBuildImportExecutor
+	 * and no comparisons are being calculated by comparisonExecutor.
+	 */
+	public boolean areAllImportsAndComparisonCalculationsFinished() {
+		return asyncBuildImportExecutor.getActiveCount() == 0 && comparisonExecutor.areAllComparisonCalculationsFinished();
 	}
 
 	private BuildImportSummary createBuildImportSummary(BuildIdentifier buildIdentifier) {
@@ -384,7 +392,7 @@ public class BuildImporter {
 	/**
 	 * Creates an executor that queues the passed tasks for execution by one single additional thread.
 	 */
-	private static ExecutorService newAsyncBuildImportExecutor() {
+	private static ThreadPoolExecutor newAsyncBuildImportExecutor() {
 		return new ThreadPoolExecutor(1, 1, 60L, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
 	}
 

--- a/scenarioo-server/src/main/java/org/scenarioo/business/builds/ScenarioDocuBuildsManager.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/business/builds/ScenarioDocuBuildsManager.java
@@ -274,6 +274,13 @@ public class ScenarioDocuBuildsManager implements AliasResolver {
 		return buildImporter.getBuildImportStatus(buildIdentifier);
 	}
 
+	/**
+	 * @return <code>true</code> if no builds are being imported and no comparisons are being calculated.
+	 */
+	public boolean areAllImportsAndComparisonCalculationsFinished() {
+		return buildImporter.areAllImportsAndComparisonCalculationsFinished();
+	}
+
 	private static ConfigurationRepository getConfigurationRepository() {
 		return RepositoryLocator.INSTANCE.getConfigurationRepository();
 	}

--- a/scenarioo-server/src/main/java/org/scenarioo/rest/builds/BuildsResource.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/rest/builds/BuildsResource.java
@@ -135,4 +135,11 @@ public class BuildsResource {
 		return new BuildUploader().uploadBuild(formData);
 	}
 
+	@GetMapping("importsAndComparisonCalculationsFinished")
+	public ResponseEntity areAllImportsAndComparisonCalculationsFinished() {
+		boolean allFinished = ScenarioDocuBuildsManager.getInstance().areAllImportsAndComparisonCalculationsFinished();
+
+		return ResponseEntity.ok(allFinished);
+	}
+
 }

--- a/scenarioo-server/src/test/java/org/scenarioo/business/diffViewer/ComparisonExecutorTest.java
+++ b/scenarioo-server/src/test/java/org/scenarioo/business/diffViewer/ComparisonExecutorTest.java
@@ -42,7 +42,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
@@ -81,7 +81,7 @@ public class ComparisonExecutorTest {
 	private Build build3 = getBuild(BUILD_NAME_3, Status.SUCCESS, getDateBeforeDays(2));
 
 	@Mock
-	private ExecutorService executorService;
+	private ThreadPoolExecutor threadPoolExecutor;
 
 	@Mock
 	private AliasResolver aliasResolver;
@@ -151,7 +151,7 @@ public class ComparisonExecutorTest {
 
 		when(docuReader.loadBuilds(BRANCH_NAME_1)).thenReturn(getBuilds());
 
-		this.comparisonExecutor = new ComparisonExecutor(executorService, aliasResolver);
+		this.comparisonExecutor = new ComparisonExecutor(threadPoolExecutor, aliasResolver);
 	}
 
 	@Test
@@ -229,6 +229,20 @@ public class ComparisonExecutorTest {
 		assertEquals(BRANCH_NAME_2, result.getBaseBranchName());
 		assertEquals(BRANCH_NAME_2, result.getComparisonBranchName());
 		assertEquals(BUILD_NAME_3, result.getComparisonBuildName());
+	}
+
+	@Test
+	public void testAreAllComparisonCalculationsFinishedWithNoRunningThreadsReturnsTrue() {
+		when(threadPoolExecutor.getActiveCount()).thenReturn(0);
+
+		assertTrue(comparisonExecutor.areAllComparisonCalculationsFinished());
+	}
+
+	@Test
+	public void testAreAllComparisonCalculationsFinishedWithRunningThreadsReturnsFalse() {
+		when(threadPoolExecutor.getActiveCount()).thenReturn(1);
+
+		assertFalse(comparisonExecutor.areAllComparisonCalculationsFinished());
 	}
 
 	private static Configuration getTestConfiguration() {


### PR DESCRIPTION
Supply rest endpoint which returns true if all imports were imported and all comparisons were calculated.

Deploy war into a running Tomcat, but wait until all wars are deployed and all imports are finished before restarting the Tomcat. When triggering updateAndImport also wait until all imports are finished.

See corresponding pull request in scenarioo-infrastructure: scenarioo/scenarioo-infrastructure#13

Replacement for pull request #890 which was based on develop.