### PR TITLE
Bugfix/897 standard jpeg content type

### DIFF
--- a/scenarioo-server/src/main/java/org/scenarioo/rest/step/ScreenshotResource.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/rest/step/ScreenshotResource.java
@@ -100,12 +100,12 @@ public class ScreenshotResource {
 	 * Additional method with produces=image/jpeg is needed, as firefox is a bit picky in its accept headers, so produces image/* does not work.
 	 */
 	@GetMapping(path = "{scenarioName}/pageName/{pageName}/pageOccurrence/{pageOccurrence}/stepInPageOccurrence/{stepInPageOccurrence}/image.{extension}", produces = "image/jpeg")
-	public ResponseEntity getScreenshotStableJpg(@PathVariable("branchName") final String branchName,
-											  @PathVariable("buildName") final String buildName, @PathVariable("usecaseName") final String usecaseName,
-											  @PathVariable("scenarioName") final String scenarioName, @PathVariable("pageName") final String pageName,
-											  @PathVariable("pageOccurrence") final int pageOccurrence,
-											  @PathVariable("stepInPageOccurrence") final int stepInPageOccurrence,
-											  @RequestParam(value="fallback", required = false) final boolean fallback, @RequestParam(value="labels", required = false) final String labels) {
+	public ResponseEntity getScreenshotStableJpeg(@PathVariable("branchName") final String branchName,
+												  @PathVariable("buildName") final String buildName, @PathVariable("usecaseName") final String usecaseName,
+												  @PathVariable("scenarioName") final String scenarioName, @PathVariable("pageName") final String pageName,
+												  @PathVariable("pageOccurrence") final int pageOccurrence,
+												  @PathVariable("stepInPageOccurrence") final int stepInPageOccurrence,
+												  @RequestParam(value="fallback", required = false) final boolean fallback, @RequestParam(value="labels", required = false) final String labels) {
 
 		return getScreenshotStable(branchName, buildName, usecaseName, scenarioName, pageName, pageOccurrence, stepInPageOccurrence, fallback, labels);
 	}

--- a/scenarioo-server/src/main/java/org/scenarioo/rest/step/ScreenshotResource.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/rest/step/ScreenshotResource.java
@@ -50,11 +50,28 @@ public class ScreenshotResource {
 	 * This method is used internally for loading the image of a step. It is the faster method, because it already knows
 	 * the filename of the image.
 	 */
-	@GetMapping(path = "{scenarioName}/image/{imageFileName}", produces = "image/*")
-	public ResponseEntity getScreenshot(@PathVariable("branchName") final String branchName,
-			@PathVariable("buildName") final String buildName, @PathVariable("usecaseName") final String usecaseName,
-			@PathVariable("scenarioName") final String scenarioName, @PathVariable("imageFileName") final String imageFileName) {
+	@GetMapping(path = "{scenarioName}/image/{imageFileName}.png", produces = "image/png")
+	public ResponseEntity getScreenshotPng(@PathVariable("branchName") final String branchName,
+										   @PathVariable("buildName") final String buildName, @PathVariable("usecaseName") final String usecaseName,
+										   @PathVariable("scenarioName") final String scenarioName, @PathVariable("imageFileName") final String imageFileName) {
 
+		return getScreenshot(branchName, buildName, usecaseName, scenarioName, imageFileName + ".png");
+	}
+
+	/**
+	 * This method is used internally for loading the image of a step. It is the faster method, because it already knows
+	 * the filename of the image.
+	 * Additional method with produces=image/jpeg is needed, as IE 11 is a bit picky in its accept headers, so produces image/* does not work for jpeg images.
+	 */
+	@GetMapping(path = "{scenarioName}/image/{imageFileName}", produces = "image/jpeg")
+	public ResponseEntity getScreenshotJpeg(@PathVariable("branchName") final String branchName,
+										   @PathVariable("buildName") final String buildName, @PathVariable("usecaseName") final String usecaseName,
+										   @PathVariable("scenarioName") final String scenarioName, @PathVariable("imageFileName") final String imageFileName) {
+
+		return getScreenshot(branchName, buildName, usecaseName, scenarioName, imageFileName);
+	}
+
+	private ResponseEntity getScreenshot(@PathVariable("branchName") String branchName, @PathVariable("buildName") String buildName, @PathVariable("usecaseName") String usecaseName, @PathVariable("scenarioName") String scenarioName, @PathVariable("imageFileName") String imageFileName) {
 		BuildIdentifier buildIdentifier = ScenarioDocuBuildsManager.getInstance().resolveBranchAndBuildAliases(branchName,
 				buildName);
 		ScenarioIdentifier scenarioIdentifier = new ScenarioIdentifier(buildIdentifier, usecaseName, scenarioName);

--- a/scenarioo-server/src/main/java/org/scenarioo/rest/step/ScreenshotResource.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/rest/step/ScreenshotResource.java
@@ -80,9 +80,9 @@ public class ScreenshotResource {
 	/**
 	 * This method is used for sharing screenshot images. It is a bit slower, because the image filename has to be
 	 * resolved first. But it is also more stable, because it uses the new "stable" URL pattern.
-	 * Additional method with produces=image/jpg is needed, as firefox is a bit picky in its accept headers, so produces image/* does not work.
+	 * Additional method with produces=image/jpeg is needed, as firefox is a bit picky in its accept headers, so produces image/* does not work.
 	 */
-	@GetMapping(path = "{scenarioName}/pageName/{pageName}/pageOccurrence/{pageOccurrence}/stepInPageOccurrence/{stepInPageOccurrence}/image.{extension}", produces = "image/jpg")
+	@GetMapping(path = "{scenarioName}/pageName/{pageName}/pageOccurrence/{pageOccurrence}/stepInPageOccurrence/{stepInPageOccurrence}/image.{extension}", produces = "image/jpeg")
 	public ResponseEntity getScreenshotStableJpg(@PathVariable("branchName") final String branchName,
 											  @PathVariable("buildName") final String buildName, @PathVariable("usecaseName") final String usecaseName,
 											  @PathVariable("scenarioName") final String scenarioName, @PathVariable("pageName") final String pageName,


### PR DESCRIPTION
The correct content type for jpeg files is "image/jpeg".

Testing with a step that returned a JPEG file, I noticed that even though the Share link worked, the Step View was broken in IE11. Thus some additional changes were needed for the getScreenshot method.

On the demo I changed one step and exchanged 000.png with a converted 000.jpg. This can be tested with the following link (the rest of the steps use regular png files):
http://demo.scenarioo.org/scenarioo-bugfix-897-standard-jpeg-content-type/#/step/Application%20Startup/First%20visit/home/0/0?branch=scenarioo-bugfix-897-standard-jpeg-content-type&build=build-1269

fixes #897 