### PR TITLE
Feature/extract components from step (WIP)

### DIFF
--- a/scenarioo-client/app/step/index.ts
+++ b/scenarioo-client/app/step/index.ts
@@ -4,7 +4,7 @@ import './screenAnnotations/annotatedScreenshot.component';
 import './screenAnnotations/screenAnnotationsButton.directive';
 import './screenAnnotations/screenAnnotationInfoPopup.controller';
 import './screenAnnotations/screenAnnotations.service';
-import './stepNotFound/stepNotFound.directive'
+import './stepNotFound/stepNotFound.directive';
 import './step.controller';
 
 declare var angular: angular.IAngularStatic;

--- a/scenarioo-client/app/step/index.ts
+++ b/scenarioo-client/app/step/index.ts
@@ -4,7 +4,7 @@ import './screenAnnotations/annotatedScreenshot.component';
 import './screenAnnotations/screenAnnotationsButton.directive';
 import './screenAnnotations/screenAnnotationInfoPopup.controller';
 import './screenAnnotations/screenAnnotations.service';
-import './stepNotFound/stepNotFound.directive';
+import './stepNotFound/stepNotFound.component';
 import './step.controller';
 
 declare var angular: angular.IAngularStatic;

--- a/scenarioo-client/app/step/index.ts
+++ b/scenarioo-client/app/step/index.ts
@@ -4,6 +4,7 @@ import './screenAnnotations/annotatedScreenshot.component';
 import './screenAnnotations/screenAnnotationsButton.directive';
 import './screenAnnotations/screenAnnotationInfoPopup.controller';
 import './screenAnnotations/screenAnnotations.service';
+import './stepNotFound/stepNotFound.directive'
 import './step.controller';
 
 declare var angular: angular.IAngularStatic;

--- a/scenarioo-client/app/step/step.controller.ts
+++ b/scenarioo-client/app/step/step.controller.ts
@@ -514,8 +514,6 @@ function StepController($scope, $routeParams, $location, $route, StepResource, S
 
     $scope.getCurrentUrlForSharing = () => $location.absUrl() + createLabelUrl('&', getAllLabels());
 
-    $scope.getCurrentUrl = () => $location.absUrl();
-
     $scope.getScreenshotUrlForSharing = () => {
         if (SelectedBranchAndBuildService.isDefined() !== true) {
             return undefined;

--- a/scenarioo-client/app/step/step.html
+++ b/scenarioo-client/app/step/step.html
@@ -17,7 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <sc-breadcrumbs></sc-breadcrumbs>
 
-<sc-step-not-found-div stepNotFound="stepNotFound" httpResponse="httpResponse"></sc-step-not-found-div>
+<sc-step-not-found-div stepNotFound="stepNotFound" response="httpResponse"></sc-step-not-found-div>
 
 <div ng-show="fallback" id="fallbackMessage">
     <div class="alert alert-warning" role="alert">

--- a/scenarioo-client/app/step/step.html
+++ b/scenarioo-client/app/step/step.html
@@ -17,16 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <sc-breadcrumbs></sc-breadcrumbs>
 
-<div ng-show="stepNotFound" id="stepNotFoundErrorMessage">
-    <div class="alert alert-warning" role="alert">
-        <div class="sc-alert-title">The step you are looking for does not exist</div>
-        <p>URL: {{getCurrentUrl()}}</p>
-        <p>REST URL to get step: {{httpResponse.url}}</p>
-        <p>HTTP method: <span id="stepNotFoundErrorResponseMethod">{{httpResponse.method}}</span></p>
-        <p>HTTP response status: <span id="stepNotFoundErrorResponseStatus">{{httpResponse.status}}</span></p>
-        <p>Response data: {{httpResponse.data}}</p>
-    </div>
-</div>
+<sc-step-not-found-div stepNotFound="stepNotFound" httpResponse="httpResponse"></sc-step-not-found-div>
 
 <div ng-show="fallback" id="fallbackMessage">
     <div class="alert alert-warning" role="alert">

--- a/scenarioo-client/app/step/step.html
+++ b/scenarioo-client/app/step/step.html
@@ -17,7 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <sc-breadcrumbs></sc-breadcrumbs>
 
-<sc-step-not-found-div stepNotFound="stepNotFound" response="httpResponse"></sc-step-not-found-div>
+<sc-step-not-found-div ng-show="stepNotFound" response="httpResponse"></sc-step-not-found-div>
 
 <div ng-show="fallback" id="fallbackMessage">
     <div class="alert alert-warning" role="alert">

--- a/scenarioo-client/app/step/stepNotFound/stepNotFound.component.ts
+++ b/scenarioo-client/app/step/stepNotFound/stepNotFound.component.ts
@@ -24,7 +24,7 @@ angular
         controller: StepNotFoundController,
     });
 
-function StepNotFoundController($location, $element) {
+function StepNotFoundController($location) {
     const ctrl = this;
 
     ctrl.getCurrentUrl = getCurrentUrl;

--- a/scenarioo-client/app/step/stepNotFound/stepNotFound.component.ts
+++ b/scenarioo-client/app/step/stepNotFound/stepNotFound.component.ts
@@ -16,22 +16,22 @@
  */
 angular
     .module('scenarioo.directives')
-    .directive('scStepNotFoundDiv', stepNotFoundDiv);
-
-function stepNotFoundDiv() {
-
-    return {
-        restrict: 'E',
-        scope: {
+    .component('scStepNotFoundDiv', {
+        bindings: {
             response: '<'
         },
         template: require('./stepNotFound.html'),
         controller: StepNotFoundController,
-        controllerAs: 'stepNotFoundDiv'
-    };
+    });
 
-    function StepNotFoundController($scope, $location,$element) {
-        $scope.getCurrentUrl = () => $location.absUrl();
+
+function StepNotFoundController($location, $element) {
+    const ctrl = this;
+
+    ctrl.getCurrentUrl = getCurrentUrl;
+
+    function getCurrentUrl(){
+        return $location.absUrl();
     }
-
 }
+

--- a/scenarioo-client/app/step/stepNotFound/stepNotFound.component.ts
+++ b/scenarioo-client/app/step/stepNotFound/stepNotFound.component.ts
@@ -18,20 +18,18 @@ angular
     .module('scenarioo.directives')
     .component('scStepNotFoundDiv', {
         bindings: {
-            response: '<'
+            response: '<',
         },
         template: require('./stepNotFound.html'),
         controller: StepNotFoundController,
     });
-
 
 function StepNotFoundController($location, $element) {
     const ctrl = this;
 
     ctrl.getCurrentUrl = getCurrentUrl;
 
-    function getCurrentUrl(){
+    function getCurrentUrl() {
         return $location.absUrl();
     }
 }
-

--- a/scenarioo-client/app/step/stepNotFound/stepNotFound.directive.js
+++ b/scenarioo-client/app/step/stepNotFound/stepNotFound.directive.js
@@ -23,7 +23,6 @@ function stepNotFoundDiv() {
     return {
         restrict: 'E',
         scope: {
-            stepNotFound: '&',
             response: '<'
         },
         template: require('./stepNotFound.html'),

--- a/scenarioo-client/app/step/stepNotFound/stepNotFound.directive.js
+++ b/scenarioo-client/app/step/stepNotFound/stepNotFound.directive.js
@@ -30,9 +30,9 @@ function stepNotFoundDiv() {
     };
 
     function StepNotFoundController($scope, $location,$element) {
-        let expressionStepNotFound = $element.attr("stepNotFound");
+        let expressionStepNotFound = $element.attr('stepNotFound');
         $scope.$parent.$watch(expressionStepNotFound, newVal => $scope.stepNotFound = newVal);
-        let expressionHttpResponse = $element.attr("httpResponse");
+        let expressionHttpResponse = $element.attr('httpResponse');
         $scope.$parent.$watch(expressionHttpResponse, newVal => $scope.httpResponse = newVal);
 
         $scope.getCurrentUrl = () => $location.absUrl();

--- a/scenarioo-client/app/step/stepNotFound/stepNotFound.directive.js
+++ b/scenarioo-client/app/step/stepNotFound/stepNotFound.directive.js
@@ -23,6 +23,8 @@ function stepNotFoundDiv() {
     return {
         restrict: 'E',
         scope: {
+            stepNotFound: '&',
+            response: '<'
         },
         template: require('./stepNotFound.html'),
         controller: StepNotFoundController,
@@ -30,13 +32,7 @@ function stepNotFoundDiv() {
     };
 
     function StepNotFoundController($scope, $location,$element) {
-        let expressionStepNotFound = $element.attr('stepNotFound');
-        $scope.$parent.$watch(expressionStepNotFound, newVal => $scope.stepNotFound = newVal);
-        let expressionHttpResponse = $element.attr('httpResponse');
-        $scope.$parent.$watch(expressionHttpResponse, newVal => $scope.httpResponse = newVal);
-
         $scope.getCurrentUrl = () => $location.absUrl();
-
     }
 
 }

--- a/scenarioo-client/app/step/stepNotFound/stepNotFound.directive.js
+++ b/scenarioo-client/app/step/stepNotFound/stepNotFound.directive.js
@@ -1,0 +1,42 @@
+/* scenarioo-client
+ * Copyright (C) 2014, scenarioo.org Development Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+angular
+    .module('scenarioo.directives')
+    .directive('scStepNotFoundDiv', stepNotFoundDiv);
+
+function stepNotFoundDiv() {
+
+    return {
+        restrict: 'E',
+        scope: {
+        },
+        template: require('./stepNotFound.html'),
+        controller: StepNotFoundController,
+        controllerAs: 'stepNotFoundDiv'
+    };
+
+    function StepNotFoundController($scope, $location,$element) {
+        let expressionStepNotFound = $element.attr("stepNotFound");
+        $scope.$parent.$watch(expressionStepNotFound, newVal => $scope.stepNotFound = newVal);
+        let expressionHttpResponse = $element.attr("httpResponse");
+        $scope.$parent.$watch(expressionHttpResponse, newVal => $scope.httpResponse = newVal);
+
+        $scope.getCurrentUrl = () => $location.absUrl();
+
+    }
+
+}

--- a/scenarioo-client/app/step/stepNotFound/stepNotFound.html
+++ b/scenarioo-client/app/step/stepNotFound/stepNotFound.html
@@ -19,9 +19,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <div class="alert alert-warning" role="alert">
         <div class="sc-alert-title">The step you are looking for does not exist</div>
         <p>URL: <span id="stepNotFoundErrorCurrentUrl">{{getCurrentUrl()}}</span></p>
-        <p>REST URL to get step: {{httpResponse.url}}</p>
-        <p>HTTP method: <span id="stepNotFoundErrorResponseMethod">{{httpResponse.method}}</span></p>
-        <p>HTTP response status: <span id="stepNotFoundErrorResponseStatus">{{httpResponse.status}}</span></p>
-        <p>Response data: {{httpResponse.data}}</p>
+        <p>REST URL to get step: {{response.url}}</p>
+        <p>HTTP method: <span id="stepNotFoundErrorResponseMethod">{{response.method}}</span></p>
+        <p>HTTP response status: <span id="stepNotFoundErrorResponseStatus">{{response.status}}</span></p>
+        <p>Response data: {{response.data}}</p>
     </div>
 </div>

--- a/scenarioo-client/app/step/stepNotFound/stepNotFound.html
+++ b/scenarioo-client/app/step/stepNotFound/stepNotFound.html
@@ -15,7 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<div ng-show="stepNotFound" id="stepNotFoundErrorMessage">
+<div id="stepNotFoundErrorMessage">
     <div class="alert alert-warning" role="alert">
         <div class="sc-alert-title">The step you are looking for does not exist</div>
         <p>URL: <span id="stepNotFoundErrorCurrentUrl">{{getCurrentUrl()}}</span></p>

--- a/scenarioo-client/app/step/stepNotFound/stepNotFound.html
+++ b/scenarioo-client/app/step/stepNotFound/stepNotFound.html
@@ -18,10 +18,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <div id="stepNotFoundErrorMessage">
     <div class="alert alert-warning" role="alert">
         <div class="sc-alert-title">The step you are looking for does not exist</div>
-        <p>URL: <span id="stepNotFoundErrorCurrentUrl">{{getCurrentUrl()}}</span></p>
-        <p>REST URL to get step: {{response.url}}</p>
-        <p>HTTP method: <span id="stepNotFoundErrorResponseMethod">{{response.method}}</span></p>
-        <p>HTTP response status: <span id="stepNotFoundErrorResponseStatus">{{response.status}}</span></p>
-        <p>Response data: {{response.data}}</p>
+        <p>URL: <span id="stepNotFoundErrorCurrentUrl">{{$ctrl.getCurrentUrl()}}</span></p>
+        <p>REST URL to get step: {{$ctrl.response.url}}</p>
+        <p>HTTP method: <span id="stepNotFoundErrorResponseMethod">{{$ctrl.response.method}}</span></p>
+        <p>HTTP response status: <span id="stepNotFoundErrorResponseStatus">{{$ctrl.response.status}}</span></p>
+        <p>Response data: {{$ctrl.response.data}}</p>
     </div>
 </div>

--- a/scenarioo-client/app/step/stepNotFound/stepNotFound.html
+++ b/scenarioo-client/app/step/stepNotFound/stepNotFound.html
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <div ng-show="stepNotFound" id="stepNotFoundErrorMessage">
     <div class="alert alert-warning" role="alert">
         <div class="sc-alert-title">The step you are looking for does not exist</div>
-        <p>URL: {{getCurrentUrl()}}</p>
+        <p>URL: <span id="stepNotFoundErrorCurrentUrl">{{getCurrentUrl()}}</span></p>
         <p>REST URL to get step: {{httpResponse.url}}</p>
         <p>HTTP method: <span id="stepNotFoundErrorResponseMethod">{{httpResponse.method}}</span></p>
         <p>HTTP response status: <span id="stepNotFoundErrorResponseStatus">{{httpResponse.status}}</span></p>

--- a/scenarioo-client/app/step/stepNotFound/stepNotFound.html
+++ b/scenarioo-client/app/step/stepNotFound/stepNotFound.html
@@ -1,0 +1,27 @@
+<!-- scenarioo-client
+Copyright (C) 2014, scenarioo.org Development Team
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<div ng-show="stepNotFound" id="stepNotFoundErrorMessage">
+    <div class="alert alert-warning" role="alert">
+        <div class="sc-alert-title">The step you are looking for does not exist</div>
+        <p>URL: {{getCurrentUrl()}}</p>
+        <p>REST URL to get step: {{httpResponse.url}}</p>
+        <p>HTTP method: <span id="stepNotFoundErrorResponseMethod">{{httpResponse.method}}</span></p>
+        <p>HTTP response status: <span id="stepNotFoundErrorResponseStatus">{{httpResponse.status}}</span></p>
+        <p>Response data: {{httpResponse.data}}</p>
+    </div>
+</div>

--- a/scenarioo-client/test/e2e/pages/stepPage.ts
+++ b/scenarioo-client/test/e2e/pages/stepPage.ts
@@ -75,7 +75,7 @@ class StepPage {
     }
 
     async assertErrorResponseIsShown(expectedCurrentUrl: string, expectedResponseMethod: string, expectedResponseStatus: string) {
-        await expect(element(by.id('stepNotFoundErrorCurrentUrl')).getText()).toEqual(expectedCurrentUrl);
+        await expect(element(by.id('stepNotFoundErrorCurrentUrl')).getText()).toContain(expectedCurrentUrl);
         await expect(element(by.id('stepNotFoundErrorResponseMethod')).getText()).toEqual(expectedResponseMethod);
         await expect(element(by.id('stepNotFoundErrorResponseStatus')).getText()).toEqual(expectedResponseStatus);
     }

--- a/scenarioo-client/test/e2e/pages/stepPage.ts
+++ b/scenarioo-client/test/e2e/pages/stepPage.ts
@@ -74,7 +74,7 @@ class StepPage {
         await expect(element(by.id('fallbackMessage')).isDisplayed()).toBeFalsy();
     }
 
-    async assertErrorResponseIsShown(expectedCurrentUrl:string, expectedResponseMethod: string, expectedResponseStatus: string) {
+    async assertErrorResponseIsShown(expectedCurrentUrl: string, expectedResponseMethod: string, expectedResponseStatus: string) {
         await expect(element(by.id('stepNotFoundErrorCurrentUrl')).getText()).toEqual(expectedCurrentUrl);
         await expect(element(by.id('stepNotFoundErrorResponseMethod')).getText()).toEqual(expectedResponseMethod);
         await expect(element(by.id('stepNotFoundErrorResponseStatus')).getText()).toEqual(expectedResponseStatus);

--- a/scenarioo-client/test/e2e/pages/stepPage.ts
+++ b/scenarioo-client/test/e2e/pages/stepPage.ts
@@ -74,7 +74,8 @@ class StepPage {
         await expect(element(by.id('fallbackMessage')).isDisplayed()).toBeFalsy();
     }
 
-    async assertErrorResponseIsShown(expectedResponseMethod: string, expectedResponseStatus: string) {
+    async assertErrorResponseIsShown(expectedCurrentUrl:string, expectedResponseMethod: string, expectedResponseStatus: string) {
+        await expect(element(by.id('stepNotFoundErrorCurrentUrl')).getText()).toEqual(expectedCurrentUrl);
         await expect(element(by.id('stepNotFoundErrorResponseMethod')).getText()).toEqual(expectedResponseMethod);
         await expect(element(by.id('stepNotFoundErrorResponseStatus')).getText()).toEqual(expectedResponseStatus);
     }

--- a/scenarioo-client/test/e2e/specs/step_view.ts
+++ b/scenarioo-client/test/e2e/specs/step_view.ts
@@ -72,7 +72,7 @@ useCase('Step - View')
             .it(async () => {
                 await Utils.navigateToRoute('/step/Find Page/find_no_results/inexistent_page.jsp/0/42');
                 await StepPage.assertErrorMessageIsShown();
-                await StepPage.assertErrorResponseIsShown('GET', '404');
+                await StepPage.assertErrorResponseIsShown('http://localhost:8500/scenarioo/#/step/Find%20Page/find_no_results/inexistent_page.jsp/0/42?branch=wikipedia-docu-example&build=last%20successful&comparison=Disabled','GET', '404');
                 await step('Error message.');
             });
 

--- a/scenarioo-client/test/e2e/specs/step_view.ts
+++ b/scenarioo-client/test/e2e/specs/step_view.ts
@@ -72,7 +72,7 @@ useCase('Step - View')
             .it(async () => {
                 await Utils.navigateToRoute('/step/Find Page/find_no_results/inexistent_page.jsp/0/42');
                 await StepPage.assertErrorMessageIsShown();
-                await StepPage.assertErrorResponseIsShown('http://localhost:8500/scenarioo/#/step/Find%20Page/find_no_results/inexistent_page.jsp/0/42?branch=wikipedia-docu-example&build=last%20successful&comparison=Disabled', 'GET', '404');
+                await StepPage.assertErrorResponseIsShown('/scenarioo/#/step/Find%20Page/find_no_results/inexistent_page.jsp/0/42?branch=wikipedia-docu-example&build=last%20successful&comparison=Disabled', 'GET', '404');
                 await step('Error message.');
             });
 

--- a/scenarioo-client/test/e2e/specs/step_view.ts
+++ b/scenarioo-client/test/e2e/specs/step_view.ts
@@ -72,7 +72,7 @@ useCase('Step - View')
             .it(async () => {
                 await Utils.navigateToRoute('/step/Find Page/find_no_results/inexistent_page.jsp/0/42');
                 await StepPage.assertErrorMessageIsShown();
-                await StepPage.assertErrorResponseIsShown('http://localhost:8500/scenarioo/#/step/Find%20Page/find_no_results/inexistent_page.jsp/0/42?branch=wikipedia-docu-example&build=last%20successful&comparison=Disabled','GET', '404');
+                await StepPage.assertErrorResponseIsShown('http://localhost:8500/scenarioo/#/step/Find%20Page/find_no_results/inexistent_page.jsp/0/42?branch=wikipedia-docu-example&build=last%20successful&comparison=Disabled', 'GET', '404');
                 await step('Error message.');
             });
 

--- a/scenarioo-client/test/spec/step/step.controller.spec.ts
+++ b/scenarioo-client/test/spec/step/step.controller.spec.ts
@@ -347,9 +347,6 @@ describe('StepController', () => {
             expect($scope.httpResponse.status).toEqual(500);
             expect($scope.httpResponse.method).toEqual('GET');
             expect($scope.httpResponse.url).toEqual('rest/branch/trunk/build/current/usecase/uc/scenario/sc/pageName/pn/pageOccurrence/0/stepInPageOccurrence/42');
-            expect($scope.getCurrentUrl()).toEqual('http://server/#?comparison=Disabled');
-            //TODO restore expected after getting rid of the mocks after the angular migration. Not quite sure where branch and build is set for $location.absUrl()
-            //expect($scope.getCurrentUrl()).toEqual('http://server/#?branch=trunk&build=current&comparison=Disabled');
         });
 
         function tryToLoadNotExistingStep() {


### PR DESCRIPTION
Step is one huge html-page and one huge controller. Extracting functionality into components will greatly simplify migration and future changes.

The first step was to extract the StepNotFound block.

@danielsuter I had problems to get the binding for stepNotFound in respect with ng-show to work inside my component, so I moved this outside. Could you quickly review these changes, so that I have an accepted baseline for further components?