### PR TITLE
Feature/804 improve release documentation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Scenarioo Standalone Runner
 
-* [#724 - Scenarioo Standalone Runner](https://github.com/scenarioo/scenarioo/issues/724): From now on you can run scnenarioo without needing to install a tomcat or similar java application server, just refer to our [Scenarioo Setup Guide](tutorial/Scenarioo-Viewer-Web-Application-Setup.md) 
+* [#724 - Scenarioo Standalone Runner](https://github.com/scenarioo/scenarioo/issues/724): From now on you can run scnenarioo without needing to install a Tomcat or similar java application server, just refer to our [Scenarioo Setup Guide](tutorial/Scenarioo-Viewer-Web-Application-Setup.md) 
 * [#778 - Secured REST Endpoints using Spring Security](https://github.com/scenarioo/scenarioo/issues/788): The way the api key (or password) for using secured REST endpoints has to be configured has fundamentaly changed by introducing Spring Security. For more details, please refer to the [Migration Guide](Migration-Guide.md) 
 
 ### Small Fixes and Improvements
@@ -21,12 +21,12 @@ The security mechanism for secured REST endpoints (e.g. to upload a build via RE
 
 Apart from this small config change there are no other breaking changes. 
 
-You can still deploy scenarioo as a WAR to your tomcat, although this is not needed anymore by using the new standalone deployment, as mentioned above. 
+You can still deploy Scenarioo as a WAR to your Tomcat, although this is not needed anymore by using the new standalone deployment, as mentioned above. 
 
 ### Supported Scenarioo Format
 
-* Used Scenarioo Data format is still version 2.1. You can safely use scenarioo 5.0 with same data format as before and do not have to upgrade any used scenarioo writer library to use new scenarioo viewer version with. 
-* Also internal format has not been changed so you do not even have to reimport your builds that have been imported with previous version in the data directory. All build and comparison data will still work with new version.
+* The used Scenarioo Data format is still version 2.1. You can safely use Scenarioo 5.0 with the same data format as before and do not have to upgrade the used Scenarioo writer library to use the new Scenarioo viewer version. 
+* The internal format has not been changed either, so you do not even have to reimport your builds that have been imported with the previous version in the data directory. All build and comparison data will still work with the new version.
 
 ### Fixed Issues
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,21 +2,44 @@
 
 ## Version 5.0.0
 
-### Migration to a Spring Boot based application
+### Scenarioo Standalone Runner
 
-* [#724 - Migration to Spring Boot](https://github.com/scenarioo/scenarioo/issues/724)
-* [#778 - Use Spring Security for REST endpoints](https://github.com/scenarioo/scenarioo/issues/788)
+* [#724 - Scenarioo Standalone Runner](https://github.com/scenarioo/scenarioo/issues/724): From now on you can run scnenarioo without needing to install a tomcat or similar java application server, just refer to our [Scenarioo Setup Guide](tutorial/Scenarioo-Viewer-Web-Application-Setup.md) 
+* [#778 - Secured REST Endpoints using Spring Security](https://github.com/scenarioo/scenarioo/issues/788): The way the api key (or password) for using secured REST endpoints has to be configured has fundamentaly changed by introducing Spring Security. For more details, please refer to the [Migration Guide](Migration-Guide.md) 
 
-With version 5, the Scenarioo application has been migrated to Spring Boot. 
-Because of the switch, the security mechanism for uploading a build via REST endpoint has changed.
-For more details, please refer to the [Migration Guide](Migration-Guide.md)
+### Small Fixes and Improvements
 
-### Bugfixes
-
-* [#727 - Build Import: UI issues](https://github.com/scenarioo/scenarioo/issues/727): Information displayed while a build is being imported was improved.
-* [#717 - Diff Viewer: Styling and UI issues](https://github.com/scenarioo/scenarioo/issues/717): Various usability improvements. 
+* [#717 - Diff Viewer: Styling and UI issues](https://github.com/scenarioo/scenarioo/issues/717): Various usability improvements.
+* [#727 - Build Import: UI issues](https://github.com/scenarioo/scenarioo/issues/727): Information displayed while a build is being imported was improved. 
 * [#895 - Share this page Screenshot link broken for Sketch](https://github.com/scenarioo/scenarioo/issues/895): The share this page dialog shows the correct image link again when sharing sketches.
 * [#900 - Application Info Popup disappears if query parameters were not provided](https://github.com/scenarioo/scenarioo/issues/900): The application information popup will now also be shown if the application is visited for the first time without query parameters.
+
+### Breaking Changes and Backwards Compatibility
+
+* **Changed Configuration of password for secured REST API calls:** 
+The security mechanism for secured REST endpoints (e.g. to upload a build via REST call) has changed. Therefore the password for these rest endpoints needs to be configured differently. For more details, please refer to the [Migration Guide](Migration-Guide.md) on how to adjust this configuration when migrating.
+
+Apart from this small config change there are no other breaking changes. 
+
+You can still deploy scenarioo as a WAR to your tomcat, although this is not needed anymore by using the new standalone deployment, as mentioned above. 
+
+### Supported Scenarioo Format
+
+* Used Scenarioo Data format is still version 2.1. You can safely use scenarioo 5.0 with same data format as before and do not have to upgrade any used scenarioo writer library to use new scenarioo viewer version with. 
+* Also internal format has not been changed so you do not even have to reimport your builds that have been imported with previous version in the data directory. All build and comparison data will still work with new version.
+
+### Fixed Issues
+
+All issues fixed in this release: [List of Fixed Issues](https://github.com/scenarioo/scenarioo/milestone/36?closed=1).
+
+### Known Issues
+
+Please visit our [List of Known Issues on GitHub](https://github.com/scenarioo/scenarioo/issues?q=is%3Aopen+is%3Aissue+label%3A%22known+issue%22).
+
+### Feedback and Support
+
+Don't hesitate to open new issues if you find a bug or problem, or have feedback or questions:
+https://github.com/scenarioo/scenarioo/issues/new?labels=feedback
 
 ## Version 4.0.1
 
@@ -82,7 +105,7 @@ All issues fixed in this release: [List of Fixed Issues](https://github.com/scen
 
 ### Known Issues
 
-Please visit our [List of Known Issues on GitHub](https://github.com/scenarioo/scenarioo/labels/known-issue).
+Please visit our [List of Known Issues on GitHub](https://github.com/scenarioo/scenarioo/issues?q=is%3Aopen+is%3Aissue+label%3A%22known+issue%22).
 
 ### Feedback and Support
 

--- a/docs/Migration-Guide.md
+++ b/docs/Migration-Guide.md
@@ -18,7 +18,7 @@ Follow these simple steps to migrate:
 
 2. Make sure you configure the same username and password for REST endpoints in the new way:
    * User and password for the HTTP authentication where usually configured in `tomcat-users.xml` before, which will not be considered anymore.
-   * Instead you can configure the same username and password now, as explained here: [Configuration of Authentication for Secured REST API](Configuration.md#authentication-for-secured-rest-api)
+   * Instead you can configure the same username and password now, as explained here: [Configuration of Authentication for Secured REST API](tutorial/Configuration.md#authentication-for-secured-rest-api)
 
 3. Restart the scenarioo server/app and enjoy the new version :-)
 

--- a/docs/Migration-Guide.md
+++ b/docs/Migration-Guide.md
@@ -1,26 +1,26 @@
 # Scenarioo Viewer Migration Guide
 
-Guide on how to upgrade for major versions of scenarioo.
+Guide on how to upgrade major versions of Scenarioo.
 
 ## 4.x to 5.x
 
 ### Breaking Changes
 
-* Security mechanism for authentication to secured REST endpoint has changed. You need to follow below steps to ensure the new deployed version has same username and password as was the case before.
+* Security mechanism for authentication to secured REST endpoint has changed. You need to follow the steps below to ensure the new deployed version has the same username and password as before.
 
 ### Migration
 
 Follow these simple steps to migrate:
 
-1. Update the scenarioo application:
-    * refer to [Scenarioo Setup Guide](tutorial/Scenarioo-Viewer-Web-Application-Setup.md) for details
-    * consider that there is a new option to also run scenarioo as a standalone web application (if you like so) instead of deploying the WAR to a web server or running it as a docker (as before)
+1. Update the Scenarioo application:
+    * refer to the [Scenarioo Setup Guide](tutorial/Scenarioo-Viewer-Web-Application-Setup.md) for details
+    * consider that there is a new option to also run Scenarioo as a standalone web application (if you prefer), instead of deploying the WAR to a web server or running it as a docker (as before)
 
 2. Make sure you configure the same username and password for REST endpoints in the new way:
-   * User and password for the HTTP authentication where usually configured in `tomcat-users.xml` before, which will not be considered anymore.
-   * Instead you can configure the same username and password now, as explained here: [Configuration of Authentication for Secured REST API](tutorial/Configuration.md#authentication-for-secured-rest-api)
+   * User and password for the HTTP authentication were usually configured in `tomcat-users.xml`, which will not be considered any longer.
+   * Instead, you can configure the same username and password in a new way. This is explained in detail here: [Configuration of Authentication for Secured REST API](tutorial/Configuration.md#authentication-for-secured-rest-api)
 
-3. Restart the scenarioo server/app and enjoy the new version :-)
+3. Restart the Scenarioo server/app and enjoy the new version :-)
 
 ## 3.x to 4.x
 

--- a/docs/Migration-Guide.md
+++ b/docs/Migration-Guide.md
@@ -4,13 +4,23 @@ Guide on how to upgrade for major versions of scenarioo.
 
 ## 4.x to 5.x
 
-### Migration to Spring Boot
+### Breaking Changes
 
-* The Scenarioo viewer has been migrated to a Spring Boot application. You can now run Scenarioo as a standalone WAR file in addition to deploying it to a webserver.
-    * Refer to the [Scenarioo setup guide](tutorial/Scenarioo-Viewer-Web-Application-Setup.md) for more information about the different ways to run Scenarioo.
-* The mechanism for securing the REST resource for build uploads has changed.
-    * User and password for the HTTP authentication can no longer be set in `tomcat-users.xml`.
-    * If you were using this feature before, read the section on [how to publish documentation data](tutorial/Publish-Documentation-Data.md#b-http-post-request) to see how this is done now.
+* Security mechanism for authentication to secured REST endpoint has changed. You need to follow below steps to ensure the new deployed version has same username and password as was the case before.
+
+### Migration
+
+Follow these simple steps to migrate:
+
+1. Update the scenarioo application:
+    * refer to [Scenarioo Setup Guide](tutorial/Scenarioo-Viewer-Web-Application-Setup.md) for details
+    * consider that there is a new option to also run scenarioo as a standalone web application (if you like so) instead of deploying the WAR to a web server or running it as a docker (as before)
+
+2. Make sure you configure the same username and password for REST endpoints in the new way:
+   * User and password for the HTTP authentication where usually configured in `tomcat-users.xml` before, which will not be considered anymore.
+   * Instead you can configure the same username and password now, as explained here: [Configuration of Authentication for Secured REST API](Configuration.md#authentication-for-secured-rest-api)
+
+3. Restart the scenarioo server/app and enjoy the new version :-)
 
 ## 3.x to 4.x
 

--- a/docs/contribute/Coding-guidelines.md
+++ b/docs/contribute/Coding-guidelines.md
@@ -111,5 +111,5 @@ https://github.com/scenarioo/scenarioo-cs/blob/master/scenarioo-cs.sln.DotSettin
 ## Licence Headers
 In every sourcefile (*.java, *.gradle, *.js, *.css, *.html,...) the correct licence header must be contained. Please always make sure that the correct header is included before adding it to version control.
 
-For the scenarioo-client module the code template settings (for *.js, *.css and *.html) in your favourite IDE must be configured by yourself (see below).
+For the scenarioo-client module the code template settings (for *.js, *.css and *.html) in your favorite IDE must be configured by yourself (see below).
 ![Code templates in WebStorms](https://raw.github.com/scenarioo/scenarioo/gh-pages/images/code_templates_in_webstorms.png)

--- a/docs/features/diff-viewer/diff-viewer.md
+++ b/docs/features/diff-viewer/diff-viewer.md
@@ -208,4 +208,4 @@ A file structure example:
          * scenarioName1
            * ...
 
-When you delete a build directory also all contained comparisons will be removed.
+When you delete a build directory all contained comparisons will be removed as well.

--- a/docs/tutorial/Configuration.md
+++ b/docs/tutorial/Configuration.md
@@ -1,8 +1,8 @@
 # Viewer Configuration
 
-Most of the features that are configurable in Scenarioo can be configured directly through the Configuration pages inside the Scenarioo webapplication. Just use the link "Manage" in the upper right corner. Most settings are on tab "General Settings" in the "Manage" area. 
+Most of the features that are configurable in Scenarioo can be configured directly through the Configuration pages inside the Scenarioo webapplication. Just use the link "Manage" in the upper right corner. Most settings are on the tab "General Settings" in the "Manage" area. 
 
-There are some more basic Application Properties and more Advanced Feature Configuration Options that can not be configured through the Scenarioo configuration pages directly. 
+There are some additional basic Application Properties and additional Advanced Feature Configuration Options that can not be configured through the Scenarioo configuration pages directly. 
 
 This page explains all these more advanced configuration options and how to configure them.
 
@@ -12,7 +12,7 @@ Application properties as described in following sections can be configured base
 
 Choose one of the following options how to configure such application properties for your kind of setup of Scenarioo:
 
-* **application.properties file** (*Suitable for: Running Scenarioo as standalone application*): simply write the properties to set into an `application.properties` file next to the standalone Scenarioo application file from where you start it. Here's a simple example to set most important properties:
+* **application.properties file** (*Suitable for: Running Scenarioo as a standalone application*): simply add the properties to set into an `application.properties` file and place it next to the standalone Scenarioo application file from where you start it. Here's a simple example to set the most important properties:
     ```
     # Data Directory
     scenarioo.data=/absolute/dir/to/your/documentation/directory
@@ -29,15 +29,15 @@ Choose one of the following options how to configure such application properties
     server.tomcat.accesslog.directory=<absolute path to log-directory>
     ```
 
-* **Environment Variables** (*Suitable for: all kind of deployments and especially the docker image deployment*): 
-Application properties can as well be set by simply setting them as environment variables, in this case you have to uppercase the same property names and use `_` instead of `.` in variable names. Some examples:
+* **Environment Variables** (*Suitable for: all kind of deployments and especially for the docker image deployment*): 
+Application properties can as well be set by simply setting them as environment variables, in this case you have to uppercase the same property names and use `_` instead of `.` in variable names. Here is an example:
     ```
     SCENARIOO_DATA=/absolute/dir/to/your/documentation/directory
     ```
-    For Scenarioo docker image you can set environment variables inside the docker container in the `dcoker run` command with option `-e`.
+    For Scenarioo docker image you can set environment variables inside the docker container in the `docker run` command with option `-e`.
 
-* **Servlet Context Parameters** (*Suitable for: Running Scenarioo on Tomcat web server*): This has the advantage that you can define different properties per Scenarioo instance on same web server if you have multiple instances of the app running. You can provide the respective properties as servlet context init parameters in the `context.xml` on your server as follows:
-    ```
+* **Servlet Context Parameters** (*Suitable for: Running Scenarioo on a Tomcat web server*): This has the advantage that you can define different properties per Scenarioo instance on the same web server if you have multiple instances of the app running. You can provide the respective properties as servlet context init parameters in the `context.xml` on your server as follows:
+    ```xml
     <Context>
         <Parameter name="spring.security.user.name" value="scenarioo" override="true" description="HTTP user for publishing documentation data"/>
         <Parameter name="spring.security.user.password" value="somePassword" override="true" description="HTTP password for publishing documentation data"/>
@@ -46,16 +46,16 @@ Application properties can as well be set by simply setting them as environment 
 
 There are many more ways how these properties can be exposed to the application. For a full list, please refer to the [Externalized Configuration](https://docs.spring.io/spring-boot/docs/2.0.2.RELEASE/reference/html/boot-features-external-config.html#boot-features-external-config) section in the official Spring Boot documentation.
 
-In following sections you find all properties you can configure like this with some explanation.
+In the following sections you can find all the properties, together with an explanation of its effects, that you can configure in this way.
 
 ### Access URL
 
-This option is only available if you not run Scenarioo as a WAR deployment that you deploy to a java web server like Tomcat. If you deploy as a WAR deployment to a web server you need to use usual server configuration possibilities to adjust the context path in the URL instead.
+This option is only available if you do not run Scenarioo as a WAR deployment that you deploy to a java web server like Tomcat. If you deploy as a WAR deployment to a web server you need to use the usual server configuration possibilities to adjust the context path in the URL instead.
 
 Simply set the application property `server.servlet.contextPath` e.g. as in following example in `application.properties` file:
-    ```
-    server.servlet.contextPath=/my-scenarioo-path
-    ```
+```
+server.servlet.contextPath=/my-scenarioo-path
+```
 
 If this application property is not set the app can be reached under the default context URL ending with `/scenarioo`.
 
@@ -64,10 +64,11 @@ See [Application Properties](#application-properties) for different ways how you
 ### Access Log
 
 You can enable Scenarioo to log all requested REST calls in a special access log, by setting following application properties:
-     ```
-     server.tomcat.accesslog.enabled=true
-     server.tomcat.accesslog.directory=<absolute path to log-directory>
-     ```
+```
+server.tomcat.accesslog.enabled=true
+server.tomcat.accesslog.directory=<absolute path to log-directory>
+```
+     
 See [Application Properties](#application-properties) for different ways how you can set such properties.         
      
 ### Authentication for Secured REST API
@@ -81,7 +82,7 @@ In this case, the default user name has been set to `scenarioo`. The random pass
 Using generated security password: 67f584b8-04e6-46b3-af57-90f037c0ca5b
 ```
 
-You can use following application properties to set the username and password differently:
+You can use the following application properties to set the username and password to different values:
 ```
 spring.security.user.name=scenarioo
 spring.security.user.password=somePassword
@@ -91,18 +92,18 @@ See [Application Properties](#application-properties) for different ways how you
 
 ## Configure Advanced Features
 
-1. Locate the `config.xml` file: it is in your Scenarioo documentation data folder that you configured. If you do not find it there: It means either that you use an older version of Scenarioo or that you never saved the configuration before. Go to the Scenarioo configuration web page and choose to save the settings once --> this will save the configuration to the file.
+1. Locate the `config.xml` file: It is in your Scenarioo documentation data folder that you configured. If you do not find it there, this means either that you use an older version of Scenarioo or that you never saved the configuration before. Go to the Scenarioo configuration web page and choose to save the settings once --> this will save the configuration to the file.
 
-2. Edit the file - according to following sections where the configurable features are explained - and save your changes.
+2. Edit the file, according to the following sections where the configurable features are explained, and save your changes.
 
-3. Restart Scenarioo such that the changes are being loaded.
+3. Restart Scenarioo so that the changes are being loaded.
 
 ### Branch Selection List Ordering
 
 The order of the branch entries in the top level navigation branch selection dropdown is configurable.
 
 Through an additional config property `branchSelectionListOrder` the following ordering options can be configured:
-* `name-ascending`: the branches are sorted by name alphabetically - default value, if value not set the behaviour is the same
+* `name-ascending`: the branches are sorted by name alphabetically - default value, if value is not set the behaviour is the same
 * `name-descending`: branches are sorted in descending order according their branch name - useful for projects that have names with version or release date or stuff like that inside
 * `last-build-date-descending`: branches are sorted by the last build date
 
@@ -117,8 +118,8 @@ Example to add in `config.xml` inside the `<configuration>`-element:
 
 ### More Advanced Feature Configurations
 
-Please refer to the documentation of advanced features for more information on how to configure those features in `config.xml`. Like for example the following advanced features:
+Please refer to the documentation of advanced features for more information on how to configure those features in `config.xml`. For example the following advanced features:
 
 * [Details & Object Repository for additional object tabs on start page](../features/Details.md)
 * [Full Text Search Setup Instructions](../features/full-text-search/setup.md)
-* [DiffViewer Setup Instructions](../features/diff-viewer/setup.md)
+* [DiffViewer Setup Instructions](../features/diff-viewer/diff-viewer.md)

--- a/docs/tutorial/Configuration.md
+++ b/docs/tutorial/Configuration.md
@@ -1,36 +1,74 @@
 # Viewer Configuration
 
-Most of the features that are configurable in Scenarioo can be configured directly through the Configuration pages inside the Scenarioo webapplication. Just use the link "Manage" in the upper right corner.
+Most of the features that are configurable in Scenarioo can be configured directly through the Configuration pages inside the Scenarioo webapplication. Just use the link "Manage" in the upper right corner. Most settings are on tab "General Settings" in the "Manage" area. 
 
-Most settings are on tab "General Settings" in the "Manage" area. 
+There are some more basic Application Properties and more Advanced Feature Configuration Options that can not be configured through the Scenarioo configuration pages directly. 
 
-There are some advanced configuration options for some advanced features that can only be configured eithe rin applicaiton properties (spring configuration file `application.properties`) or through the viewer's `config.xml` file and can not be configured through the Scenarioo configuration pages directly. 
+This page explains all these more advanced configuration options and how to configure them.
 
-This page explains all these more advanced configuraiton options.
+## Application Properties
 
-## Configure Major Application Properties
+Application properties as described in following sections can be configured based on the flexibility of Spring Boot configuration property resolution in different ways.
 
-Following features can be configured using spring properties, those properties can be set in `application.properties` file that you have to create next to your WAR file.
+Choose one of the following options how to configure such application properties for your kind of setup of scenarioo:
 
-After changing values you have to restart the application server.
+* **application.properties file** (*Suitable for: Running Scenarioo as standalone application*): simply write the properties to set into an `application.properties` file next to the standalone scenarioo application file from where you start it. Here's a simple example to set most important properties:
+    ```
+    # Data Directory
+    scenarioo.data=/absolute/dir/to/your/documentation/directory
+    
+    # Context path for scenarioo URL
+    server.servlet.contextPath=/scenarioo
+    
+    # REST Endpoint protection username and password
+    spring.security.user.name=scenarioo
+    spring.security.user.password=<putSomeSecurePasswordHere>
+    
+    # Access Log Config
+    server.tomcat.accesslog.enabled=true
+    server.tomcat.accesslog.directory=<absolute path to log-directory>
+    ```
 
-### Access URL (Standalone runner only)
+* **Environment Variables** (*Suitable for: all kind of deployments and especially the docker image deployment*): 
+Application properties can as well be set by simply setting them as environment variables, in this case you have to uppercase the same property names and use `_` insted of `.` in variable names. Some examples:
+    ```
+    SCENARIOO_DATA=/absolute/dir/to/your/documentation/directory
+    ```
+    For scenarioo docker image you can set environment variables inside the docker container in the `dcoker run` command with option `-e`.
 
-This option is only available if you run scenarioo as standalone app and do not deploy the WAR to a java webserver like tomcat. If you deploy using a server you need to use usual server configuration possibilities to adjust the context path in the URL.
+* **Servlet Context Parameters** (*Suitable for: Running Scenarioo on tomcat web server*): This has the advantage that you can define different properties per scenarioo instance on same web server if you have multiple instances of the app running. You can provide the respective properties as servlet context init parameters in the `context.xml` on your server as follows:
+    ```
+    <Context>
+        <Parameter name="spring.security.user.name" value="scenarioo" override="true" description="HTTP user for publishing documentation data"/>
+        <Parameter name="spring.security.user.password" value="somePassword" override="true" description="HTTP password for publishing documentation data"/>
+    </Context>    
+    ```
 
-Configure the access URL under which the app should be deployed by creating the file `application.properties` next to the downloaded standalone runnable war, with the following entry
+There are many more ways how these properties can be exposed to the application. For a full list, please refer to the [Externalized Configuration](https://docs.spring.io/spring-boot/docs/2.0.2.RELEASE/reference/html/boot-features-external-config.html#boot-features-external-config) section in the official Spring Boot documentation.
+
+In following sections you find all properties you can configure like this with some explanation.
+
+### Access URL
+
+This option is only available if you not run scenarioo as a WAR deployment that you deploy to a java web server like tomcat. If you deploy as a WAR deployment to a web server you need to use usual server configuration possibilities to adjust the context path in the URL instead.
+
+Simply set the application property `server.servlet.contextPath` e.g. as in following example in `application.properties` file:
     ```
     server.servlet.contextPath=/my-scenarioo-path
     ```
-If this file or property in the file is missing, the app can be reached under the default context URL ending with `/scenarioo`.
+
+If this application property is not set the app can be reached under the default context URL ending with `/scenarioo`.
+
+See [Application Properties](#application-properties) for different ways how you can set such properties.         
 
 ### Access Log
 
-You can enable scenarioo to log all requested REST calls in a special access log, if you wish so in `application.properties`:
+You can enable scenarioo to log all requested REST calls in a special access log, by setting following application properties:
      ```
      server.tomcat.accesslog.enabled=true
      server.tomcat.accesslog.directory=<absolute path to log-directory>
      ```
+See [Application Properties](#application-properties) for different ways how you can set such properties.         
      
 ### Authentication for Secured REST API
 
@@ -43,45 +81,13 @@ In this case, the default user name has been set to `scenarioo`. The random pass
 Using generated security password: 67f584b8-04e6-46b3-af57-90f037c0ca5b
 ```
 
-Based on the flexibility of Spring Boot configuration property resolution, there are various ways how the user/password combination can be overridden.
-
-#### Provide an application.properties file
-
-*Suitable for: Running Scenarioo as standalone WAR*.
-
+You can use following application properties to set the username and password differently:
 ```
 spring.security.user.name=scenarioo
 spring.security.user.password=somePassword
 ```
 
-For more information on where the application.properties file should be placed and what other configuration options it offers see [Setup of Scenarioo Viewer Web App](Scenarioo-Viewer-Web-Application-Setup.md#running-scenarioo-as-standalone-application). 
-
-#### Provide as environment variables
-
-*Suitable for: Running Scenarioo as Docker image or standalone WAR*
-
-Because of the underlying configuration property resolution, it is possible to define them as environment variables like this:
-
-```
-SPRING_SECURITY_USER_NAME=scenarioo
-SPRING_SECURITY_USER_PASSWORD=somePassword
-```
-
-#### Provide as servlet context parameters
-
-*Suitable for: Running Scenarioo on a separate Tomcat web server*
-
-To configure user and password on a Tomcat, you can provide the respective properties as servlet context init parameters in the `context.xml`.
-
-```
-<Context>
-    <Parameter name="spring.security.user.name" value="scenarioo" override="true" description="HTTP user for publishing documentation data"/>
-    <Parameter name="spring.security.user.password" value="somePassword" override="true" description="HTTP password for publishing documentation data"/>
-</Context>    
-```
-
-There are many more ways how these properties can be exposed to the application. For a full list, please refer to the [Externalized Configuration](https://docs.spring.io/spring-boot/docs/2.0.2.RELEASE/reference/html/boot-features-external-config.html#boot-features-external-config) 
-section in the official Spring Boot documentation.
+See [Application Properties](#application-properties) for different ways how you can set such properties.         
 
 ## Configure Advanced Features
 

--- a/docs/tutorial/Configuration.md
+++ b/docs/tutorial/Configuration.md
@@ -10,9 +10,9 @@ This page explains all these more advanced configuration options and how to conf
 
 Application properties as described in following sections can be configured based on the flexibility of Spring Boot configuration property resolution in different ways.
 
-Choose one of the following options how to configure such application properties for your kind of setup of scenarioo:
+Choose one of the following options how to configure such application properties for your kind of setup of Scenarioo:
 
-* **application.properties file** (*Suitable for: Running Scenarioo as standalone application*): simply write the properties to set into an `application.properties` file next to the standalone scenarioo application file from where you start it. Here's a simple example to set most important properties:
+* **application.properties file** (*Suitable for: Running Scenarioo as standalone application*): simply write the properties to set into an `application.properties` file next to the standalone Scenarioo application file from where you start it. Here's a simple example to set most important properties:
     ```
     # Data Directory
     scenarioo.data=/absolute/dir/to/your/documentation/directory
@@ -30,13 +30,13 @@ Choose one of the following options how to configure such application properties
     ```
 
 * **Environment Variables** (*Suitable for: all kind of deployments and especially the docker image deployment*): 
-Application properties can as well be set by simply setting them as environment variables, in this case you have to uppercase the same property names and use `_` insted of `.` in variable names. Some examples:
+Application properties can as well be set by simply setting them as environment variables, in this case you have to uppercase the same property names and use `_` instead of `.` in variable names. Some examples:
     ```
     SCENARIOO_DATA=/absolute/dir/to/your/documentation/directory
     ```
-    For scenarioo docker image you can set environment variables inside the docker container in the `dcoker run` command with option `-e`.
+    For Scenarioo docker image you can set environment variables inside the docker container in the `dcoker run` command with option `-e`.
 
-* **Servlet Context Parameters** (*Suitable for: Running Scenarioo on tomcat web server*): This has the advantage that you can define different properties per scenarioo instance on same web server if you have multiple instances of the app running. You can provide the respective properties as servlet context init parameters in the `context.xml` on your server as follows:
+* **Servlet Context Parameters** (*Suitable for: Running Scenarioo on Tomcat web server*): This has the advantage that you can define different properties per Scenarioo instance on same web server if you have multiple instances of the app running. You can provide the respective properties as servlet context init parameters in the `context.xml` on your server as follows:
     ```
     <Context>
         <Parameter name="spring.security.user.name" value="scenarioo" override="true" description="HTTP user for publishing documentation data"/>
@@ -50,7 +50,7 @@ In following sections you find all properties you can configure like this with s
 
 ### Access URL
 
-This option is only available if you not run scenarioo as a WAR deployment that you deploy to a java web server like tomcat. If you deploy as a WAR deployment to a web server you need to use usual server configuration possibilities to adjust the context path in the URL instead.
+This option is only available if you not run Scenarioo as a WAR deployment that you deploy to a java web server like Tomcat. If you deploy as a WAR deployment to a web server you need to use usual server configuration possibilities to adjust the context path in the URL instead.
 
 Simply set the application property `server.servlet.contextPath` e.g. as in following example in `application.properties` file:
     ```
@@ -63,7 +63,7 @@ See [Application Properties](#application-properties) for different ways how you
 
 ### Access Log
 
-You can enable scenarioo to log all requested REST calls in a special access log, by setting following application properties:
+You can enable Scenarioo to log all requested REST calls in a special access log, by setting following application properties:
      ```
      server.tomcat.accesslog.enabled=true
      server.tomcat.accesslog.directory=<absolute path to log-directory>
@@ -72,7 +72,7 @@ See [Application Properties](#application-properties) for different ways how you
      
 ### Authentication for Secured REST API
 
-Some REST APIs (e.g. for publishing documentation data) are secured by a password. This password can be configured in several ways depending on your scenarioo server setup:
+Some REST APIs (e.g. for publishing documentation data) are secured by a password. This password can be configured in several ways depending on your Scenarioo server setup:
 
 By default, Spring Security in a Spring Boot 2 application configures a user `user` with a random password to secure all REST endpoints.
 In this case, the default user name has been set to `scenarioo`. The random password is printed in the log output at application startup and looks like this:
@@ -91,11 +91,11 @@ See [Application Properties](#application-properties) for different ways how you
 
 ## Configure Advanced Features
 
-1. Locate the `config.xml` file: it is in your scenarioo documentation data folder that you configured. If you do not find it there: It means either that you use an older version of scenarioo or that you never saved the configuration before. Go to the Scenarioo configuraiton web page and choose to save the settings once --> this will save the configuration to the file.
+1. Locate the `config.xml` file: it is in your Scenarioo documentation data folder that you configured. If you do not find it there: It means either that you use an older version of Scenarioo or that you never saved the configuration before. Go to the Scenarioo configuration web page and choose to save the settings once --> this will save the configuration to the file.
 
 2. Edit the file - according to following sections where the configurable features are explained - and save your changes.
 
-3. Restart scenarioo such that the changes are being loaded.
+3. Restart Scenarioo such that the changes are being loaded.
 
 ### Branch Selection List Ordering
 

--- a/docs/tutorial/Configuration.md
+++ b/docs/tutorial/Configuration.md
@@ -4,19 +4,43 @@ Most of the features that are configurable in Scenarioo can be configured direct
 
 Most settings are on tab "General Settings" in the "Manage" area. 
 
-There are some advanced configuration options for some advanced features that can only be configured through the viewer's `config.xml` file and can not be configured yet through the Scenarioo configuration pages directly. 
+There are some advanced configuration options for some advanced features that can only be configured eithe rin applicaiton properties (spring configuration file `application.properties`) or through the viewer's `config.xml` file and can not be configured through the Scenarioo configuration pages directly. 
 
-This page briefly explains how you can use that `config.xml` file to configure more advanced options.
+This page explains all these more advanced configuraiton options.
 
-## How to change `config.xml`
+## Configure Major Application Properties
+
+Following features can be configured using spring properties, those properties can be set in `application.properties` file that you have to create next to your WAR file.
+
+After changing values you have to restart the application server.
+
+### Access URL (Standalone runner only)
+
+This option is only available if you run scenarioo as standalone app and do not deploy the WAR to a java webserver like tomcat. If you deploy using a server you need to use usual server configuration possibilities to adjust the context path in the URL.
+
+Configure the access URL under which the app should be deployed by creating the file `application.properties` next to the downloaded standalone runnable war, with the following entry
+    ```
+    server.servlet.contextPath=/my-scenarioo-path
+    ```
+If this file or property in the file is missing, the app can be reached under the default context URL ending with `/scenarioo`.
+
+### Access Log
+
+You can enable scenarioo to log all requested REST calls in a special access log, if you wish so in `application.properties`:
+     ```
+     server.tomcat.accesslog.enabled=true
+     server.tomcat.accesslog.directory=<absolute path to log-directory>
+     ```
+
+## Configure Advanced Features
 
 1. Locate the `config.xml` file: it is in your scenarioo documentation data folder that you configured. If you do not find it there: It means either that you use an older version of scenarioo or that you never saved the configuration before. Go to the Scenarioo configuraiton web page and choose to save the settings once --> this will save the configuration to the file.
 
-2. Edit the file - See next section about an example - and save your changes.
+2. Edit the file - according to following sections where the configurable features are explained - and save your changes.
 
 3. Restart scenarioo such that the changes are being loaded.
 
-## Branch Selection List Ordering
+### Branch Selection List Ordering
 
 The order of the branch entries in the top level navigation branch selection dropdown is configurable.
 
@@ -34,7 +58,7 @@ Example to add in `config.xml` inside the `<configuration>`-element:
 </configuration>
 ```
 
-## More Advanced Feature Configurations
+### More Advanced Feature Configurations
 
 Please refer to the documentation of advanced features for more information on how to configure those features in `config.xml`. Like for example the following advanced features:
 

--- a/docs/tutorial/Configuration.md
+++ b/docs/tutorial/Configuration.md
@@ -31,6 +31,57 @@ You can enable scenarioo to log all requested REST calls in a special access log
      server.tomcat.accesslog.enabled=true
      server.tomcat.accesslog.directory=<absolute path to log-directory>
      ```
+     
+### Authentication for Secured REST API
+
+Some REST APIs (e.g. for publishing documentation data) are secured by a password. This password can be configured in several ways depending on your scenarioo server setup:
+
+By default, Spring Security in a Spring Boot 2 application configures a user `user` with a random password to secure all REST endpoints.
+In this case, the default user name has been set to `scenarioo`. The random password is printed in the log output at application startup and looks like this:
+
+```
+Using generated security password: 67f584b8-04e6-46b3-af57-90f037c0ca5b
+```
+
+Based on the flexibility of Spring Boot configuration property resolution, there are various ways how the user/password combination can be overridden.
+
+#### Provide an application.properties file
+
+*Suitable for: Running Scenarioo as standalone WAR*.
+
+```
+spring.security.user.name=scenarioo
+spring.security.user.password=somePassword
+```
+
+For more information on where the application.properties file should be placed and what other configuration options it offers see [Setup of Scenarioo Viewer Web App](Scenarioo-Viewer-Web-Application-Setup.md#running-scenarioo-as-standalone-application). 
+
+#### Provide as environment variables
+
+*Suitable for: Running Scenarioo as Docker image or standalone WAR*
+
+Because of the underlying configuration property resolution, it is possible to define them as environment variables like this:
+
+```
+SPRING_SECURITY_USER_NAME=scenarioo
+SPRING_SECURITY_USER_PASSWORD=somePassword
+```
+
+#### Provide as servlet context parameters
+
+*Suitable for: Running Scenarioo on a separate Tomcat web server*
+
+To configure user and password on a Tomcat, you can provide the respective properties as servlet context init parameters in the `context.xml`.
+
+```
+<Context>
+    <Parameter name="spring.security.user.name" value="scenarioo" override="true" description="HTTP user for publishing documentation data"/>
+    <Parameter name="spring.security.user.password" value="somePassword" override="true" description="HTTP password for publishing documentation data"/>
+</Context>    
+```
+
+There are many more ways how these properties can be exposed to the application. For a full list, please refer to the [Externalized Configuration](https://docs.spring.io/spring-boot/docs/2.0.2.RELEASE/reference/html/boot-features-external-config.html#boot-features-external-config) 
+section in the official Spring Boot documentation.
 
 ## Configure Advanced Features
 

--- a/docs/tutorial/Publish-Documentation-Data.md
+++ b/docs/tutorial/Publish-Documentation-Data.md
@@ -2,11 +2,11 @@
 
 Documentation data can be published in two ways.
 
-## A) Copy into documentation directory
+## A) Copy into the documentation directory
 
-1. Generate or copy the data into the directory that Scenarioo shows under `Manage > General Settings > General > Documentation Data Directory Path`. This folder can be changed, see [Setup of Scenarioo Viewer Web App](Scenarioo-Viewer-Web-Application-Setup.md). In case you are generating your documentation directly into this directory you should write the `build.xml` file as the last file, to ensure that a build does not get imported before all required files are available.
+1. Generate or copy the data into the directory that Scenarioo shows under `Manage > General Settings > General > Documentation Data Directory Path`. To change this folder, see [Setup of Scenarioo Viewer Web App](Scenarioo-Viewer-Web-Application-Setup.md#installation-and-setup). In case that you are generating your documentation directly into this directory you should write the `build.xml` file as the last file, to ensure that a build does not get imported before all required files are available.
 
-2. To import newly added builds call the HTTP GET REST endpoint `<your-scenarioo-url>/rest/builds/updateAndImport` to update the currently available builds and importing unimported (newly added) build(s).
+2. To import newly added builds call the HTTP GET REST endpoint `<your-scenarioo-url>/rest/builds/updateAndImport` to update the currently available builds and start importing unimported (newly added) build(s).
 
 **Up to Version 2.0.1 of Scenarioo, this is the only possible way to publish data.**
 

--- a/docs/tutorial/Publish-Documentation-Data.md
+++ b/docs/tutorial/Publish-Documentation-Data.md
@@ -18,52 +18,7 @@ Since version 2.1.0 of the Scenarioo viewer web application we also allow adding
 
 ### Configure the user/password
 
-By default, Spring Security in a Spring Boot 2 application configures a user `user` with a random password to secure all REST endpoints.
-In this case, the default user name has been set to `scenarioo`. The random password is printed in the log output at application startup and looks like this:
-
-```
-Using generated security password: 67f584b8-04e6-46b3-af57-90f037c0ca5b
-```
-
-Based on the flexibility of Spring Boot configuration property resolution, there are various ways how the user/password combination can be overridden.
-
-#### Provide an application.properties file
-
-*Suitable for: Running Scenarioo as standalone WAR*.
-
-```
-spring.security.user.name=scenarioo
-spring.security.user.password=somePassword
-```
-
-For more information on where the application.properties file should be placed and what other configuration options it offers see [Setup of Scenarioo Viewer Web App](Scenarioo-Viewer-Web-Application-Setup.md#running-scenarioo-as-standalone-application). 
-
-#### Provide as environment variables
-
-*Suitable for: Running Scenarioo as Docker image or standalone WAR*
-
-Because of the underlying configuration property resolution, it is possible to define them as environment variables like this:
-
-```
-SPRING_SECURITY_USER_NAME=scenarioo
-SPRING_SECURITY_USER_PASSWORD=somePassword
-```
-
-#### Provide as servlet context parameters
-
-*Suitable for: Running Scenarioo on a separate Tomcat web server*
-
-To configure user and password on a Tomcat, you can provide the respective properties as servlet context init parameters in the `context.xml`.
-
-```
-<Context>
-    <Parameter name="spring.security.user.name" value="scenarioo" override="true" description="HTTP user for publishing documentation data"/>
-    <Parameter name="spring.security.user.password" value="somePassword" override="true" description="HTTP password for publishing documentation data"/>
-</Context>    
-```
-
-There are many more ways how these properties can be exposed to the application. For a full list, please refer to the [Externalized Configuration](https://docs.spring.io/spring-boot/docs/2.0.2.RELEASE/reference/html/boot-features-external-config.html#boot-features-external-config) 
-section in the official Spring Boot documentation.
+To configure the username and password to access this HTTP REST API please refer to the documentation about [Configuration of Authentication for Secured REST API](Configuration.md#authentication-for-secured-rest-api) 
 
 ### Usage
 

--- a/docs/tutorial/Quickstart-JS.md
+++ b/docs/tutorial/Quickstart-JS.md
@@ -139,7 +139,7 @@ npm test
  
 * Configure the Scenarioo data directory where Scenarioo can store and read its data.  Create the file `application.properties` next to the downloaded war with the following line:  
     ```
-    org.scenarioo.data=<path to a directory where scenarioo can store its data>
+    scenarioo.data=<path to a directory where scenarioo can store its data>
     ```
 
 * Start up Scenarioo with `java -jar scenarioo-x.y.z.war`.

--- a/docs/tutorial/Scenarioo-Viewer-Docker-Image.md
+++ b/docs/tutorial/Scenarioo-Viewer-Docker-Image.md
@@ -39,6 +39,6 @@ How to set up and run the Scenarioo Viewer Web App as a docker image:
 
 * [Viewer Web App Setup Instructions](Scenarioo-Viewer-Web-Application-Setup.md), to refer to in case of troubles with the web app setup inside the docker image.
 
-* [Viewer Configuration](Configuration.md) for more advanced configuraiton options.
+* [Viewer Configuration](Configuration.md) for more advanced configuration options.
 
 * [Publish Documentation Data](Publish-Documentation-Data.md) for how to publish documentation data to the Scenarioo Viewer Web App.

--- a/docs/tutorial/Scenarioo-Viewer-Web-Application-Setup.md
+++ b/docs/tutorial/Scenarioo-Viewer-Web-Application-Setup.md
@@ -11,19 +11,19 @@ The latest stable Scenarioo web application WAR file can be downloaded from the 
 
 Scenarioo requires Java 8 or higher. 
 
-You can directly run the standalone runnable WAR without needing to install any application server or you can choose to deploy it to your application server of choice (e.g. tomcat), this is up to you. See next section about installation and setup.
+You can directly run the standalone runnable WAR without needing to install any application server or you can choose to deploy it to your application server of choice (e.g. Tomcat), this is up to you. See next section about installation and setup.
 
 Further Release Candidate Versions are available through [Downloads & Links](../downloads-and-links.md), if you want to to test newer versions not yet officially released.
 
 ## Installation and Setup
 
 Choose one of the two following setups explained in following sections:
-* **[Setup 1 - Running as Standalone Application](#setup-1---running-as-standalone-application):** Scenarioo is packaged as spring boot application with an included tomcat web server to run it directly without the need to install and deploy to a web server. 
-* **[Setup 2 - Deploy WAR on Web Server](#setup-2---deploy-war-on-web-server):** this is as before the standalone runner was available, you need to have a web server (like e.g. tomcat) you can deploy to.
+* **[Setup 1 - Running as Standalone Application](#setup-1---running-as-standalone-application):** Scenarioo is packaged as Spring Boot application with an included Tomcat web server to run it directly without the need to install and deploy to a web server. 
+* **[Setup 2 - Deploy WAR on Web Server](#setup-2---deploy-war-on-web-server):** this works the same way as before the standalone runner was available, you need to have a web server (like e.g. Tomcat) you can deploy to.
 
 ### Setup 1 - Running as Standalone Application
 
-Run scenarioo directly without the need to install a web server.
+Run Scenarioo directly without the need to install a web server.
 
 1. **Configure the Scenarioo data directory** where Scenarioo can store and read its data. By default Scenarioo is using a folder `.scenarioo` in your "user.home"-directory.
     
@@ -44,12 +44,12 @@ Run scenarioo directly without the need to install a web server.
 
 ### Setup 2 - Deploy WAR on Web Server
 
-Alternatively you can deploy the scenarioo WAR file into your favorite Webserver (e.g.Tomcat).
+Alternatively you can deploy the Scenarioo WAR file into your favorite webserver (e.g.Tomcat).
 
-1. **Install a Tomcat Webserver** or any other favourite Java webserver (Tomcat 8.5.31+ or 9 should all work with Scenarioo). You can download and unzip one from from http://tomcat.apache.org/ 
+1. **Install a Tomcat webserver** or any other favourite Java webserver (Tomcat 8.5.31+ or 9 should all work with Scenarioo). You can download and unzip one from from http://tomcat.apache.org/ 
 
 2. **Configure the Scenarioo data directory** where Scenarioo can store and read its data. By default Scenarioo is using a folder `.scenarioo` in your "user.home"-directory.
-    * To configure a different directory to use add the following line to context.xml in your webserver's installation directory (usually located in folder 'conf' of your tomcat installation):  
+    * To configure a different directory to use add the following line to context.xml in your webserver's installation directory (usually located in folder 'conf' of your Tomcat installation):  
 `<Parameter name="scenariooDataDirectory" value=">>>path to a directory where scenarioo can store its data<<<" override="true" description="Location of Scenarioo data"/>`
     * Alternatively you can set an environment variable called `SCENARIOO_DATA` for the user under which Tomcat is running and define the path there
     * Make sure that the Tomcat user has the correct access rights for the folder (permission to create files and directories inside). Under linux systems you can do this with following commands:
@@ -59,7 +59,7 @@ Alternatively you can deploy the scenarioo WAR file into your favorite Webserver
      ```
     * The config.xml file will be created for you automatically in this directory by the Scenarioo Viewer Web Application when you do some configuration changes inside the webapplication for the first time and save it.
     
-3. **Deploy the WAR** file into it, e.g. simply copy the WAR file into the webapps folder on tomcat. 
+3. **Deploy the WAR** file into it, e.g. simply copy the WAR file into the webapps folder in Tomcat. 
     * If you use a release candidate WAR file that has the version in the name, then make sure to rename the war to simply `scenarioo.war` before deploying it, because the name defines the context under which you can access the app.
 
 4. **Start the Tomcat Server** (or whatever java server you are using)

--- a/docs/tutorial/Scenarioo-Viewer-Web-Application-Setup.md
+++ b/docs/tutorial/Scenarioo-Viewer-Web-Application-Setup.md
@@ -4,28 +4,34 @@
 
 Instead of installing the Scenarioo Viewer web app by yourself (as described below) you can simply run Scenarioo as a docker image: See [Scenarioo Viewer Docker Image](Scenarioo-Viewer-Docker-Image.md) for instructions.
 
-## Download as WAR
+## Download
 
 The latest stable Scenarioo web application WAR file can be downloaded from the release section:
 [Scenarioo Webapplication Releases](https://github.com/scenarioo/scenarioo/releases)
 
-Scenarioo requires Java 8 or higher.
+Scenarioo requires Java 8 or higher. 
+
+You can directly run the standalone runnable WAR without needing to install any application server or you can choose to deploy it to your application server of choice (e.g. tomcat), this is up to you. See next section about installation and setup.
 
 Further Release Candidate Versions are available through [Downloads & Links](../downloads-and-links.md), if you want to to test newer versions not yet officially released.
 
 ## Installation and Setup
 
-### Running Scenarioo as Standalone Application
+Choose one of the two following setups explained in following sections:
+* **[Setup 1 - Running as Standalone Application](#setup-1---running-as-standalone-application):** Scenarioo is packaged as spring boot application with an included tomcat web server to run it directly without the need to install and deploy to a web server. 
+* **[Setup 2 - Deploy WAR on Web Server](#setup-2---deploy-war-on-web-server):** this is as before the standalone runner was available, you need to have a web server (like e.g. tomcat) you can deploy to.
+
+### Setup 1 - Running as Standalone Application
+
+Run scenarioo directly without the need to install a web server.
 
 1. **Configure the Scenarioo data directory** where Scenarioo can store and read its data. By default Scenarioo is using a folder `.scenarioo` in your "user.home"-directory.
     
-    To configure a different directory to use add the following line to `application.properties` next to the downloaded war:  
+    To configure a different data directory either set the environment variable `SCENARIOO_DATA` or add the following line to `application.properties` next to the downloaded war:  
     ```
     scenarioo.data=<path to a directory where scenarioo can store its data>
     ```
     
-    
-
 2. **Execute the WAR** file with Java, e.g 
      ```
      cd <war-location>
@@ -36,9 +42,9 @@ Further Release Candidate Versions are available through [Downloads & Links](../
 
 4. **Configure your Viewer and advanced features (optional)** as described in [Viewer Configuration](Configuration.md).
 
-### Installing Scenarioo on Webserver
+### Setup 2 - Deploy WAR on Web Server
 
-Alternatively you can install your favorite Webserver (e.g.Tomcat) and deploy the WAR into it.
+Alternatively you can deploy the scenarioo WAR file into your favorite Webserver (e.g.Tomcat).
 
 1. **Install a Tomcat Webserver** or any other favourite Java webserver (Tomcat 8.5.31+ or 9 should all work with Scenarioo). You can download and unzip one from from http://tomcat.apache.org/ 
 

--- a/docs/tutorial/Scenarioo-Viewer-Web-Application-Setup.md
+++ b/docs/tutorial/Scenarioo-Viewer-Web-Application-Setup.md
@@ -2,7 +2,7 @@
 
 ## Use as Docker Image
 
-Instead of installing the Scenarioo Viewer web app by yourself (as described below) you can simply run Scenarioo as a docker image: See [Scenarioo Viewer Docker Image](Scenarioo-Viewer-Docker-Image.md) for instructions.
+Instead of installing the Scenarioo Viewer web application by yourself (as described below) you can simply run Scenarioo as a docker image: See [Scenarioo Viewer Docker Image](Scenarioo-Viewer-Docker-Image.md) for instructions.
 
 ## Download
 
@@ -11,15 +11,15 @@ The latest stable Scenarioo web application WAR file can be downloaded from the 
 
 Scenarioo requires Java 8 or higher. 
 
-You can directly run the standalone runnable WAR without needing to install any application server or you can choose to deploy it to your application server of choice (e.g. Tomcat), this is up to you. See next section about installation and setup.
+You can directly run the standalone runnable WAR without needing to install any application server, or you can choose to deploy it to your application server of choice (e.g. Tomcat), this is up to you. See the next section about installation and setup.
 
 Further Release Candidate Versions are available through [Downloads & Links](../downloads-and-links.md), if you want to to test newer versions not yet officially released.
 
 ## Installation and Setup
 
-Choose one of the two following setups explained in following sections:
+Choose one of the two following setups explained in the following sections:
 * **[Setup 1 - Running as Standalone Application](#setup-1---running-as-standalone-application):** Scenarioo is packaged as Spring Boot application with an included Tomcat web server to run it directly without the need to install and deploy to a web server. 
-* **[Setup 2 - Deploy WAR on Web Server](#setup-2---deploy-war-on-web-server):** this works the same way as before the standalone runner was available, you need to have a web server (like e.g. Tomcat) you can deploy to.
+* **[Setup 2 - Deploy WAR on Web Server](#setup-2---deploy-war-on-web-server):** This works the same way as before the standalone runner was available, you need to have a web server (like e.g. Tomcat) you can deploy to.
 
 ### Setup 1 - Running as Standalone Application
 
@@ -38,7 +38,7 @@ Run Scenarioo directly without the need to install a web server.
      java -jar scenarioo.war
      ```
 
-3. **Startup Scenarioo Viewer Web App** through your browser using following URL: http://{your-ip-address-and-port-or-host-url}/scenarioo (e.g. http://localhost:8080/scenarioo )
+3. **Startup Scenarioo Viewer Web App** through your browser using the following URL: http://{your-ip-address-and-port-or-host-url}/scenarioo (e.g. http://localhost:8080/scenarioo )
 
 4. **Configure your Viewer and advanced features (optional)** as described in [Viewer Configuration](Configuration.md).
 
@@ -46,17 +46,17 @@ Run Scenarioo directly without the need to install a web server.
 
 Alternatively you can deploy the Scenarioo WAR file into your favorite webserver (e.g.Tomcat).
 
-1. **Install a Tomcat webserver** or any other favourite Java webserver (Tomcat 8.5.31+ or 9 should all work with Scenarioo). You can download and unzip one from from http://tomcat.apache.org/ 
+1. **Install a Tomcat webserver** or any other favorite Java webserver (Tomcat 8.5.31+ or 9 should all work with Scenarioo). You can download and unzip one from here: http://tomcat.apache.org/ 
 
 2. **Configure the Scenarioo data directory** where Scenarioo can store and read its data. By default Scenarioo is using a folder `.scenarioo` in your "user.home"-directory.
-    * To configure a different directory to use add the following line to context.xml in your webserver's installation directory (usually located in folder 'conf' of your Tomcat installation):  
+    * To configure a different directory to use, add the following line to context.xml in your webserver's installation directory (usually located in folder 'conf' of your Tomcat installation):  
 `<Parameter name="scenariooDataDirectory" value=">>>path to a directory where scenarioo can store its data<<<" override="true" description="Location of Scenarioo data"/>`
     * Alternatively you can set an environment variable called `SCENARIOO_DATA` for the user under which Tomcat is running and define the path there
     * Make sure that the Tomcat user has the correct access rights for the folder (permission to create files and directories inside). Under linux systems you can do this with following commands:
-     ```
-     sudo chown -R tomcat: <scenarioo-docu-directory>
-     sudo chmod ug+rws <scenarioo-docu-directory> 
-     ```
+      ```
+      sudo chown -R tomcat: <scenarioo-docu-directory>
+      sudo chmod ug+rws <scenarioo-docu-directory> 
+      ```
     * The config.xml file will be created for you automatically in this directory by the Scenarioo Viewer Web Application when you do some configuration changes inside the webapplication for the first time and save it.
     
 3. **Deploy the WAR** file into it, e.g. simply copy the WAR file into the webapps folder in Tomcat. 

--- a/docs/tutorial/Scenarioo-Viewer-Web-Application-Setup.md
+++ b/docs/tutorial/Scenarioo-Viewer-Web-Application-Setup.md
@@ -14,33 +14,31 @@ Scenarioo requires Java 8 or higher.
 Further Release Candidate Versions are available through [Downloads & Links](../downloads-and-links.md), if you want to to test newer versions not yet officially released.
 
 ## Installation and Setup
-### Running Scenarioo as standalone application
-1. **Configure the context** under which the app should be deployed by creating the file `application.properties` next to the downloaded war, with the following entry
-     ```
-     server.servlet.contextPath=/scenarioo
-     ```
-     If this file is missing, the app can be reached under the default context `scenarioo`.
-     
-     The Tomcat access log can also be enabled using `application.properties`. Just add the following entries:
-     ```
-     server.tomcat.accesslog.enabled=true
-     server.tomcat.accesslog.directory=<absolute path to log-directory>
-     ```
-2. **Configure the Scenarioo data directory** where Scenarioo can store and read its data. By default Scenarioo is using a folder `.scenarioo` in your "user.home"-directory.
+
+### Running Scenarioo as Standalone Application
+
+1. **Configure the Scenarioo data directory** where Scenarioo can store and read its data. By default Scenarioo is using a folder `.scenarioo` in your "user.home"-directory.
     
     To configure a different directory to use add the following line to `application.properties` next to the downloaded war:  
     ```
     scenarioo.data=<path to a directory where scenarioo can store its data>
     ```
+    
+    
 
-3. **Execute the WAR** file with Java, e.g 
+2. **Execute the WAR** file with Java, e.g 
      ```
      cd <war-location>
      java -jar scenarioo.war
      ```
 
-### Installing Scenarioo into a Webserver
-Alternatively you can install your favorite Webserver and deploy the WAR into it.
+3. **Startup Scenarioo Viewer Web App** through your browser using following URL: http://{your-ip-address-and-port-or-host-url}/scenarioo (e.g. http://localhost:8080/scenarioo )
+
+4. **Configure your Viewer and advanced features (optional)** as described in [Viewer Configuration](Configuration.md).
+
+### Installing Scenarioo on Webserver
+
+Alternatively you can install your favorite Webserver (e.g.Tomcat) and deploy the WAR into it.
 
 1. **Install a Tomcat Webserver** or any other favourite Java webserver (Tomcat 8.5.31+ or 9 should all work with Scenarioo). You can download and unzip one from from http://tomcat.apache.org/ 
 


### PR DESCRIPTION
Some improvements for release 5.0 documentation

* migration guide more concrete
* all little bit more consumer oriented than dev oriented
* changelog with usual additional blocks according our "template"
* moved new configuration possibiliteies to configuration docu page and adjusted a lot of links (untestedt!)

