### PR TITLE
#871 Provide development artifacts for download again

### DIFF
--- a/docs/downloads-and-links.md
+++ b/docs/downloads-and-links.md
@@ -13,12 +13,14 @@ This page informs you where you can get the different versions (stable and unsta
 ### Release Candidate (develop)
 
 Our current release candidate on the develop branch can be found here (it may include unstable new functionality):
+
+* **Download as WAR from the [overview page](http://demo.scenarioo.org/overview/)** (Click on ``Download WAR`` underneath ``develop``)
  
 * **Live-Demo [demo.scenarioo.org/scenarioo-develop](http://demo.scenarioo.org/scenarioo-develop)**
 
 ### Other Special Versions
 
-For some other feature branches, there might be a deployed demo application. You can find the list of deployed applications [here](http://demo.scenarioo.org/overview/)
+For some feature branches, there might be a deployed demo application with a link to a WAR download. You can find the list of deployed applications [here](http://demo.scenarioo.org/overview/) 
 
 ## Scenarioo Writer Libraries
 


### PR DESCRIPTION
# Problem
Since the migration to CircleCI, it is not possible anymore to download the WAR files from the latest develop and feature branch builds, if the user is not logged in on CircleCI. Before, one could download them via a direct link to the respective Jenkins build. This needs to be fixed.

It could also be possible to provide the latest artifacts via our demo server, for example. It is not yet clear if CirlceCI can provide similar functionality like Jenkins (pointing to the latest successful build, providing artifacts on the build overview)

# Acceptance criteria
- It is possible to download the WAR file from the latest develop branch build
- It is possible to download the WAR file from the latest builds of the feature branches
- The user does not have to be logged in on CircleCI for downloading the artifact
- The documentation is updated with the new download links. (`docs/downloads-and-links.md`)

# Solution
- Provide a download link on the Demo Overview Page, because we have this information as part of the demo-json-files.
- This link works even if the user is not logged in to CircleCI.
- This has already been updated on scenarioo-infrastructure. This PR is for review of those changes, as well as the changes in the documentation

fixes #871 