### PR TITLE
Feature/402 fix rest upload

### DIFF
--- a/scenarioo-server/build.gradle
+++ b/scenarioo-server/build.gradle
@@ -77,8 +77,6 @@ dependencies {
     compile 'org.elasticsearch.client:transport'
     compile 'org.springframework.boot:spring-boot-starter-web'
     compile 'org.springframework.boot:spring-boot-starter-security'
-    compile 'commons-io:commons-io'
-    compile 'commons-fileupload:commons-fileupload'
 
     providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
 

--- a/scenarioo-server/src/main/java/org/scenarioo/ScenariooViewerApplication.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/ScenariooViewerApplication.java
@@ -13,8 +13,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.security.web.firewall.HttpFirewall;
 import org.springframework.security.web.firewall.StrictHttpFirewall;
-import org.springframework.web.multipart.commons.CommonsMultipartResolver;
-import org.springframework.web.servlet.config.annotation.*;
+import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import javax.annotation.PostConstruct;
 import java.util.Collections;

--- a/scenarioo-server/src/main/java/org/scenarioo/ScenariooViewerApplication.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/ScenariooViewerApplication.java
@@ -49,17 +49,6 @@ public class ScenariooViewerApplication extends SpringBootServletInitializer imp
 		return corsFilterBean;
 	}
 
-	/**
-	 * Needed to enable multipart upload for large ZIP file uploads.
-	 */
-	@Bean(name = "multipartResolver")
-	public CommonsMultipartResolver multipartResolver() {
-		CommonsMultipartResolver multipartResolver = new CommonsMultipartResolver();
-		multipartResolver.setMaxUploadSize(-1);
-		multipartResolver.setMaxUploadSizePerFile(-1);
-		return multipartResolver;
-	}
-
 	@Override
 	public void addInterceptors(InterceptorRegistry registry) {
 		registry.addInterceptor(new RequestLoggingFilter());

--- a/scenarioo-server/src/main/java/org/scenarioo/business/uploadBuild/BuildUploader.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/business/uploadBuild/BuildUploader.java
@@ -65,7 +65,7 @@ public class BuildUploader {
 	private void saveAndExtractBuildAndStartImport(final MultipartFile file) throws BuildUploaderException {
 
 		File documentationDataDirectory = configurationRepository.getDocumentationDataDirectory();
-		File temporaryWorkDirectory = new File(documentationDataDirectory, "uploadedBuild_"
+		File temporaryWorkDirectory = new File(documentationDataDirectory.getAbsolutePath(), "uploadedBuild_"
 				+ Long.toString(new Date().getTime()));
 		boolean tempDirCreated = temporaryWorkDirectory.mkdir();
 		LOGGER.debug(String.format("TempDir %s created: %b", temporaryWorkDirectory.getAbsolutePath(), tempDirCreated));

--- a/scenarioo-server/src/main/java/org/scenarioo/utils/ZipFileExtractor.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/utils/ZipFileExtractor.java
@@ -61,6 +61,8 @@ public class ZipFileExtractor {
 			}
 		} catch (IOException e) {
 			throw new ZipFileExtractionException("IO Error while extracting ZIP file.", e);
+		} finally {
+			IOUtils.closeQuietly(zipFile);
 		}
 	}
 

--- a/scenarioo-server/src/main/resources/application.properties
+++ b/scenarioo-server/src/main/resources/application.properties
@@ -7,3 +7,5 @@ spring.security.user.roles=scenarioo-build-publisher
 
 # Allow uploading of large ZIP files to upload builds
 server.tomcat.max-http-post-size=-1
+spring.servlet.multipart.max-file-size=-1
+spring.servlet.multipart.max-request-size=-1


### PR DESCRIPTION
In issue #402 it was detected that uploading the self-docu of the pizza-delivery-example failed. 

The problem was the MultiPartResolver configuration.

Setting the configuration of the multipart upload values in application.properties worked, but led to a problem in StandardMultipartFile, which was caused because the target file had a relative path. Using a fixed path solved this issue.

Locally I had another issue, that after every upload the cleanup of the temporary directory failed. The cause of this was that the ZipFile was not properly closed in ZipFileExtractor.

fixes #934 