### PR TITLE
#951 Scenarioo docker image set workdir to scenarioo.war location

### DIFF
--- a/docker/scenarioo/Dockerfile
+++ b/docker/scenarioo/Dockerfile
@@ -9,5 +9,7 @@ ENV SCENARIOO_DATA /scenarioo/data
 # ADD SCENARIOO.WAR TO DOCKER IMAGE
 ADD ./scenarioo-latest.war /scenarioo/bin/scenarioo.war
 
+WORKDIR /scnearioo/bin
+
 # RUN TOMCAT
 CMD java -Xms400m -Xmx800m -jar /scenarioo/bin/scenarioo.war

--- a/docker/scenarioo/Dockerfile
+++ b/docker/scenarioo/Dockerfile
@@ -9,7 +9,7 @@ ENV SCENARIOO_DATA /scenarioo/data
 # ADD SCENARIOO.WAR TO DOCKER IMAGE
 ADD ./scenarioo-latest.war /scenarioo/bin/scenarioo.war
 
-WORKDIR /scnearioo/bin
+WORKDIR /scenarioo/bin
 
 # RUN TOMCAT
 CMD java -Xms400m -Xmx800m -jar /scenarioo/bin/scenarioo.war


### PR DESCRIPTION
Fix #951 by setting workdir to scnearioo.war location. Spring will now load the application.properties next to the scenarioo.war.