### PR TITLE
Set explicit version of webdriver-manager in package.json to ensure t…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,7 @@ jobs:
   build:
     docker:
       # See https://circleci.com/docs/2.0/circleci-images/ ...
-      # circleci/openjdk:8-jdk-browsers
-      - image: circleci/openjdk:8-jdk-browsers
+      - image: circleci/openjdk:8-jdk-stretch-browsers
       - image: docker.elastic.co/elasticsearch/elasticsearch:5.6.9
         environment:
           cluster.name: elasticsearch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     docker:
       # See https://circleci.com/docs/2.0/circleci-images/ ...
       # circleci/openjdk:8-jdk-browsers
-      - image: circleci/openjdk@sha256:fa630780e340d81ad974a06c9104e7c337b906186c42586ee61ec571eec730d3
+      - image: circleci/openjdk:8-jdk-browsers
       - image: docker.elastic.co/elasticsearch/elasticsearch:5.6.9
         environment:
           cluster.name: elasticsearch

--- a/scenarioo-client/package-lock.json
+++ b/scenarioo-client/package-lock.json
@@ -9,7 +9,7 @@
             "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-7.2.14.tgz",
             "integrity": "sha512-K+wdq7TslmvDhrbwy65x7owE8wezI0fDdO+8SO9RU4m/w6R6vo4QS3uSdc5I2pxwm4QSXSc5eKhoWJkq0muTbQ==",
             "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.9.0"
             }
         },
         "@angular/common": {
@@ -17,7 +17,7 @@
             "resolved": "https://registry.npmjs.org/@angular/common/-/common-7.2.14.tgz",
             "integrity": "sha512-c2QBhVpbQhg1FDhOQkyVdFvU11mfvYHW5ZaXzxdCpq2rZXCureYiCSnlv++EsIAKqi22+2a6GACHF9Gh8kBmSg==",
             "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.9.0"
             },
             "dependencies": {
                 "tslib": {
@@ -32,7 +32,7 @@
             "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-7.2.14.tgz",
             "integrity": "sha512-Idhs+5HIzx+1+hrXIDaRpSqobMB7UvSvPlvCvtb3EDYjmltTNG68TtwMzGM8W2jdayliYuFOjFrnw1wCTkK3Ag==",
             "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.9.0"
             },
             "dependencies": {
                 "tslib": {
@@ -47,7 +47,7 @@
             "resolved": "https://registry.npmjs.org/@angular/core/-/core-7.2.14.tgz",
             "integrity": "sha512-XeZZJCyBKSKo0E/7Ef0SfJejmn+E7uBXa5cR1QapafS0Hnrq/hZu/NI039IDU/51NoycMDH2vTV19SmKu9Mkow==",
             "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.9.0"
             },
             "dependencies": {
                 "tslib": {
@@ -62,7 +62,7 @@
             "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-7.2.14.tgz",
             "integrity": "sha512-jL5YbTk7VZmz4l0++iFVUNa1vGM+nnALjHKi1Ub8VWioRDRboYUsHyxzlgWW9gZRbHpnLEXFiUz1td+v7TouJw==",
             "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.9.0"
             },
             "dependencies": {
                 "tslib": {
@@ -77,7 +77,7 @@
             "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-7.2.14.tgz",
             "integrity": "sha512-yAq2+3W4J4B48HEmZYQucdEb9AHwRnv72q9CC/SxU7g59vaLhl1nv7cAWGJ4XFaJTbB7aB4Y4rLffuR+Gxkn7A==",
             "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.9.0"
             },
             "dependencies": {
                 "tslib": {
@@ -92,7 +92,7 @@
             "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-7.2.14.tgz",
             "integrity": "sha512-lmTCBiDRbOPtniIqBjm1n5jl1TdyQM0qWQdBcoCsKpMNS/6/RacRcQsJZApAMdWm6gIVuLgmRQzaCLkSoekfYA==",
             "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.9.0"
             },
             "dependencies": {
                 "tslib": {
@@ -107,7 +107,7 @@
             "resolved": "https://registry.npmjs.org/@angular/router/-/router-7.2.14.tgz",
             "integrity": "sha512-uqg0SKy79voEOIOvzVbCzFDD9XOAfZWkYt01ca2qLFXMx+6jWeVQIDuXc8Dmz5udIXNK5Ae//9R+nt5UZUZrSA==",
             "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.9.0"
             },
             "dependencies": {
                 "tslib": {
@@ -122,7 +122,7 @@
             "resolved": "https://registry.npmjs.org/@angular/upgrade/-/upgrade-7.2.14.tgz",
             "integrity": "sha512-KWgIxrkUYNi67Na/Ue0Gzi4r+kSi7LVsaoYxHebiKZmcrnclIMpEEk9v9/YN1jyZCxdxXBK+LCne7VMhmgAZSw==",
             "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.9.0"
             },
             "dependencies": {
                 "tslib": {
@@ -138,7 +138,7 @@
             "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
             "dev": true,
             "requires": {
-                "@babel/highlight": "7.0.0"
+                "@babel/highlight": "^7.0.0"
             }
         },
         "@babel/highlight": {
@@ -147,9 +147,9 @@
             "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.2",
-                "esutils": "2.0.2",
-                "js-tokens": "4.0.0"
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^4.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -158,7 +158,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.0"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -167,9 +167,9 @@
                     "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.5.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "has-flag": {
@@ -190,7 +190,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -200,7 +200,7 @@
             "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome/-/fontawesome-1.1.8.tgz",
             "integrity": "sha512-c0/MtkPVT0fmiFcCyYoPjkG9PkMOvfrZw2+0BaJ+Rh6UEcK1AR/LaRgrHHjUkbAbs9LXxQJhFS8CJ4uSnK2+JA==",
             "requires": {
-                "@fortawesome/fontawesome-common-types": "0.1.7"
+                "@fortawesome/fontawesome-common-types": "^0.1.7"
             }
         },
         "@fortawesome/fontawesome-common-types": {
@@ -213,7 +213,7 @@
             "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free-brands/-/fontawesome-free-brands-5.0.13.tgz",
             "integrity": "sha512-xC/sEPpfcJPvUbud2GyscLCLQlE2DVBYaTHVwuyVGliYBdYejSEYMINU8FN5A0xhO68yCbpCfMlBv6Gqby+jww==",
             "requires": {
-                "@fortawesome/fontawesome-common-types": "0.1.7"
+                "@fortawesome/fontawesome-common-types": "^0.1.7"
             }
         },
         "@fortawesome/fontawesome-free-solid": {
@@ -221,7 +221,7 @@
             "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free-solid/-/fontawesome-free-solid-5.0.13.tgz",
             "integrity": "sha512-b+krVnqkdDt52Yfev0x0ZZgtxBQsLw00Zfa3uaVWIDzpNZVtrEXuxldUSUaN/ihgGhSNi8VpvDAdNPVgCKOSxw==",
             "requires": {
-                "@fortawesome/fontawesome-common-types": "0.1.7"
+                "@fortawesome/fontawesome-common-types": "^0.1.7"
             }
         },
         "@types/angular": {
@@ -236,7 +236,7 @@
             "integrity": "sha512-C8ipXVKQvw+w64kH97Npa3a7uZB7ZL9Kr4+sOe33oYIyxeg09M8bzAWCIYCmPRRV0px6ozFTZeSVjBXDikz2zw==",
             "dev": true,
             "requires": {
-                "@types/angular": "1.6.39"
+                "@types/angular": "*"
             }
         },
         "@types/jasmine": {
@@ -251,7 +251,7 @@
             "integrity": "sha512-hYDVmQZT5VA2kigd4H4bv7vl/OhlympwREUemqBdOqtrYTo5Ytm12a5W5/nGgGYdanGVxj0x/VhZ7J3hOg/YKg==",
             "dev": true,
             "requires": {
-                "@types/jasmine": "2.8.7"
+                "@types/jasmine": "*"
             }
         },
         "@types/node": {
@@ -278,7 +278,7 @@
             "integrity": "sha1-1xyW99QdD+2iw4zRToonwEFY30o=",
             "dev": true,
             "requires": {
-                "mime-types": "2.0.14",
+                "mime-types": "~2.0.4",
                 "negotiator": "0.4.9"
             },
             "dependencies": {
@@ -294,7 +294,7 @@
                     "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
                     "dev": true,
                     "requires": {
-                        "mime-db": "1.12.0"
+                        "mime-db": "~1.12.0"
                     }
                 }
             }
@@ -311,7 +311,7 @@
             "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
             "dev": true,
             "requires": {
-                "acorn": "4.0.13"
+                "acorn": "^4.0.3"
             },
             "dependencies": {
                 "acorn": {
@@ -328,7 +328,7 @@
             "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
             "dev": true,
             "requires": {
-                "acorn": "3.3.0"
+                "acorn": "^3.0.4"
             },
             "dependencies": {
                 "acorn": {
@@ -357,7 +357,7 @@
             "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
             "dev": true,
             "requires": {
-                "es6-promisify": "5.0.0"
+                "es6-promisify": "^5.0.0"
             }
         },
         "ajv": {
@@ -365,10 +365,10 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.0.tgz",
             "integrity": "sha1-6yhAdG6dxIvV4GOjbj/UAMXqtak=",
             "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.0.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
             }
         },
         "ajv-keywords": {
@@ -383,9 +383,9 @@
             "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2",
-                "longest": "1.0.1",
-                "repeat-string": "1.6.1"
+                "kind-of": "^3.0.2",
+                "longest": "^1.0.1",
+                "repeat-string": "^1.5.2"
             }
         },
         "alphanum-sort": {
@@ -465,8 +465,8 @@
             "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
             "dev": true,
             "requires": {
-                "micromatch": "2.3.11",
-                "normalize-path": "2.1.1"
+                "micromatch": "^2.1.5",
+                "normalize-path": "^2.0.0"
             }
         },
         "argparse": {
@@ -475,7 +475,7 @@
             "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
             "dev": true,
             "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
             }
         },
         "arr-diff": {
@@ -484,7 +484,7 @@
             "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
             "dev": true,
             "requires": {
-                "arr-flatten": "1.1.0"
+                "arr-flatten": "^1.0.1"
             }
         },
         "arr-flatten": {
@@ -511,7 +511,7 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
@@ -557,9 +557,9 @@
             "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.0"
+                "bn.js": "^4.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "assert": {
@@ -601,12 +601,12 @@
             "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
             "dev": true,
             "requires": {
-                "browserslist": "1.7.7",
-                "caniuse-db": "1.0.30000772",
-                "normalize-range": "0.1.2",
-                "num2fraction": "1.2.2",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "browserslist": "^1.7.6",
+                "caniuse-db": "^1.0.30000634",
+                "normalize-range": "^0.1.2",
+                "num2fraction": "^1.2.2",
+                "postcss": "^5.2.16",
+                "postcss-value-parser": "^3.2.3"
             }
         },
         "aws-sign2": {
@@ -627,9 +627,9 @@
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
             }
         },
         "babel-core": {
@@ -638,25 +638,25 @@
             "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
             "dev": true,
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "babel-generator": "6.26.1",
-                "babel-helpers": "6.24.1",
-                "babel-messages": "6.23.0",
-                "babel-register": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "convert-source-map": "1.6.0",
-                "debug": "2.6.9",
-                "json5": "0.5.1",
-                "lodash": "4.17.11",
-                "minimatch": "3.0.4",
-                "path-is-absolute": "1.0.1",
-                "private": "0.1.8",
-                "slash": "1.0.0",
-                "source-map": "0.5.7"
+                "babel-code-frame": "^6.26.0",
+                "babel-generator": "^6.26.0",
+                "babel-helpers": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-register": "^6.26.0",
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "convert-source-map": "^1.5.1",
+                "debug": "^2.6.9",
+                "json5": "^0.5.1",
+                "lodash": "^4.17.4",
+                "minimatch": "^3.0.4",
+                "path-is-absolute": "^1.0.1",
+                "private": "^0.1.8",
+                "slash": "^1.0.0",
+                "source-map": "^0.5.7"
             },
             "dependencies": {
                 "debug": {
@@ -688,14 +688,14 @@
             "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
             "dev": true,
             "requires": {
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "detect-indent": "4.0.0",
-                "jsesc": "1.3.0",
-                "lodash": "4.17.11",
-                "source-map": "0.5.7",
-                "trim-right": "1.0.1"
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "detect-indent": "^4.0.0",
+                "jsesc": "^1.3.0",
+                "lodash": "^4.17.4",
+                "source-map": "^0.5.7",
+                "trim-right": "^1.0.1"
             },
             "dependencies": {
                 "jsesc": {
@@ -718,9 +718,9 @@
             "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
             "dev": true,
             "requires": {
-                "babel-helper-explode-assignable-expression": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-explode-assignable-expression": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-call-delegate": {
@@ -729,10 +729,10 @@
             "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
             "dev": true,
             "requires": {
-                "babel-helper-hoist-variables": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-hoist-variables": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-define-map": {
@@ -741,10 +741,10 @@
             "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
             "dev": true,
             "requires": {
-                "babel-helper-function-name": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "lodash": "4.17.11"
+                "babel-helper-function-name": "^6.24.1",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "lodash": "^4.17.4"
             },
             "dependencies": {
                 "lodash": {
@@ -761,9 +761,9 @@
             "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-function-name": {
@@ -772,11 +772,11 @@
             "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
             "dev": true,
             "requires": {
-                "babel-helper-get-function-arity": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-get-function-arity": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-get-function-arity": {
@@ -785,8 +785,8 @@
             "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-hoist-variables": {
@@ -795,8 +795,8 @@
             "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-optimise-call-expression": {
@@ -805,8 +805,8 @@
             "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-regex": {
@@ -815,9 +815,9 @@
             "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "lodash": "4.17.11"
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "lodash": "^4.17.4"
             },
             "dependencies": {
                 "lodash": {
@@ -834,11 +834,11 @@
             "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
             "dev": true,
             "requires": {
-                "babel-helper-function-name": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-function-name": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-replace-supers": {
@@ -847,12 +847,12 @@
             "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
             "dev": true,
             "requires": {
-                "babel-helper-optimise-call-expression": "6.24.1",
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-optimise-call-expression": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helpers": {
@@ -861,8 +861,8 @@
             "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
             }
         },
         "babel-loader": {
@@ -871,9 +871,9 @@
             "integrity": "sha512-iCHfbieL5d1LfOQeeVJEUyD9rTwBcP/fcEbRCfempxTDuqrKpu0AZjLAQHEQa3Yqyj9ORKe2iHfoj4rHLf7xpw==",
             "dev": true,
             "requires": {
-                "find-cache-dir": "1.0.0",
-                "loader-utils": "1.2.3",
-                "mkdirp": "0.5.1"
+                "find-cache-dir": "^1.0.0",
+                "loader-utils": "^1.0.2",
+                "mkdirp": "^0.5.1"
             },
             "dependencies": {
                 "big.js": {
@@ -888,7 +888,7 @@
                     "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
                     "dev": true,
                     "requires": {
-                        "minimist": "1.2.0"
+                        "minimist": "^1.2.0"
                     }
                 },
                 "loader-utils": {
@@ -897,9 +897,9 @@
                     "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
                     "dev": true,
                     "requires": {
-                        "big.js": "5.2.2",
-                        "emojis-list": "2.1.0",
-                        "json5": "1.0.1"
+                        "big.js": "^5.2.2",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^1.0.1"
                     }
                 }
             }
@@ -910,7 +910,7 @@
             "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-check-es2015-constants": {
@@ -919,7 +919,7 @@
             "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-syntax-async-functions": {
@@ -946,9 +946,9 @@
             "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
             "dev": true,
             "requires": {
-                "babel-helper-remap-async-to-generator": "6.24.1",
-                "babel-plugin-syntax-async-functions": "6.13.0",
-                "babel-runtime": "6.26.0"
+                "babel-helper-remap-async-to-generator": "^6.24.1",
+                "babel-plugin-syntax-async-functions": "^6.8.0",
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-arrow-functions": {
@@ -957,7 +957,7 @@
             "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -966,7 +966,7 @@
             "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-block-scoping": {
@@ -975,11 +975,11 @@
             "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "lodash": "4.17.11"
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "lodash": "^4.17.4"
             },
             "dependencies": {
                 "lodash": {
@@ -996,15 +996,15 @@
             "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
             "dev": true,
             "requires": {
-                "babel-helper-define-map": "6.26.0",
-                "babel-helper-function-name": "6.24.1",
-                "babel-helper-optimise-call-expression": "6.24.1",
-                "babel-helper-replace-supers": "6.24.1",
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-define-map": "^6.24.1",
+                "babel-helper-function-name": "^6.24.1",
+                "babel-helper-optimise-call-expression": "^6.24.1",
+                "babel-helper-replace-supers": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-computed-properties": {
@@ -1013,8 +1013,8 @@
             "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-destructuring": {
@@ -1023,7 +1023,7 @@
             "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-duplicate-keys": {
@@ -1032,8 +1032,8 @@
             "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-for-of": {
@@ -1042,7 +1042,7 @@
             "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-function-name": {
@@ -1051,9 +1051,9 @@
             "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
             "dev": true,
             "requires": {
-                "babel-helper-function-name": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-function-name": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-literals": {
@@ -1062,7 +1062,7 @@
             "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-modules-amd": {
@@ -1071,9 +1071,9 @@
             "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
             "dev": true,
             "requires": {
-                "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
+                "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-modules-commonjs": {
@@ -1082,10 +1082,10 @@
             "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
             "dev": true,
             "requires": {
-                "babel-plugin-transform-strict-mode": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-plugin-transform-strict-mode": "^6.24.1",
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-types": "^6.26.0"
             }
         },
         "babel-plugin-transform-es2015-modules-systemjs": {
@@ -1094,9 +1094,9 @@
             "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
             "dev": true,
             "requires": {
-                "babel-helper-hoist-variables": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
+                "babel-helper-hoist-variables": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-modules-umd": {
@@ -1105,9 +1105,9 @@
             "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
             "dev": true,
             "requires": {
-                "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
+                "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-object-super": {
@@ -1116,8 +1116,8 @@
             "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
             "dev": true,
             "requires": {
-                "babel-helper-replace-supers": "6.24.1",
-                "babel-runtime": "6.26.0"
+                "babel-helper-replace-supers": "^6.24.1",
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-parameters": {
@@ -1126,12 +1126,12 @@
             "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
             "dev": true,
             "requires": {
-                "babel-helper-call-delegate": "6.24.1",
-                "babel-helper-get-function-arity": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-call-delegate": "^6.24.1",
+                "babel-helper-get-function-arity": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-shorthand-properties": {
@@ -1140,8 +1140,8 @@
             "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-spread": {
@@ -1150,7 +1150,7 @@
             "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-sticky-regex": {
@@ -1159,9 +1159,9 @@
             "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
             "dev": true,
             "requires": {
-                "babel-helper-regex": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-regex": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-template-literals": {
@@ -1170,7 +1170,7 @@
             "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-typeof-symbol": {
@@ -1179,7 +1179,7 @@
             "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-unicode-regex": {
@@ -1188,9 +1188,9 @@
             "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
             "dev": true,
             "requires": {
-                "babel-helper-regex": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "regexpu-core": "2.0.0"
+                "babel-helper-regex": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "regexpu-core": "^2.0.0"
             },
             "dependencies": {
                 "regexpu-core": {
@@ -1199,9 +1199,9 @@
                     "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
                     "dev": true,
                     "requires": {
-                        "regenerate": "1.3.3",
-                        "regjsgen": "0.2.0",
-                        "regjsparser": "0.1.5"
+                        "regenerate": "^1.2.1",
+                        "regjsgen": "^0.2.0",
+                        "regjsparser": "^0.1.4"
                     }
                 }
             }
@@ -1212,9 +1212,9 @@
             "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
             "dev": true,
             "requires": {
-                "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-                "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-                "babel-runtime": "6.26.0"
+                "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+                "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-regenerator": {
@@ -1223,7 +1223,7 @@
             "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
             "dev": true,
             "requires": {
-                "regenerator-transform": "0.10.1"
+                "regenerator-transform": "^0.10.0"
             }
         },
         "babel-plugin-transform-strict-mode": {
@@ -1232,8 +1232,8 @@
             "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-polyfill": {
@@ -1241,9 +1241,9 @@
             "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
             "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
             "requires": {
-                "babel-runtime": "6.26.0",
-                "core-js": "2.5.1",
-                "regenerator-runtime": "0.10.5"
+                "babel-runtime": "^6.26.0",
+                "core-js": "^2.5.0",
+                "regenerator-runtime": "^0.10.5"
             }
         },
         "babel-preset-env": {
@@ -1252,36 +1252,36 @@
             "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
             "dev": true,
             "requires": {
-                "babel-plugin-check-es2015-constants": "6.22.0",
-                "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-                "babel-plugin-transform-async-to-generator": "6.24.1",
-                "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-                "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-                "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-                "babel-plugin-transform-es2015-classes": "6.24.1",
-                "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-                "babel-plugin-transform-es2015-destructuring": "6.23.0",
-                "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-                "babel-plugin-transform-es2015-for-of": "6.23.0",
-                "babel-plugin-transform-es2015-function-name": "6.24.1",
-                "babel-plugin-transform-es2015-literals": "6.22.0",
-                "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-                "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-                "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-                "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-                "babel-plugin-transform-es2015-object-super": "6.24.1",
-                "babel-plugin-transform-es2015-parameters": "6.24.1",
-                "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-                "babel-plugin-transform-es2015-spread": "6.22.0",
-                "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-                "babel-plugin-transform-es2015-template-literals": "6.22.0",
-                "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-                "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-                "babel-plugin-transform-exponentiation-operator": "6.24.1",
-                "babel-plugin-transform-regenerator": "6.26.0",
-                "browserslist": "3.2.8",
-                "invariant": "2.2.4",
-                "semver": "5.4.1"
+                "babel-plugin-check-es2015-constants": "^6.22.0",
+                "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+                "babel-plugin-transform-async-to-generator": "^6.22.0",
+                "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+                "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+                "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+                "babel-plugin-transform-es2015-classes": "^6.23.0",
+                "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+                "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+                "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+                "babel-plugin-transform-es2015-for-of": "^6.23.0",
+                "babel-plugin-transform-es2015-function-name": "^6.22.0",
+                "babel-plugin-transform-es2015-literals": "^6.22.0",
+                "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+                "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+                "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+                "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+                "babel-plugin-transform-es2015-object-super": "^6.22.0",
+                "babel-plugin-transform-es2015-parameters": "^6.23.0",
+                "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+                "babel-plugin-transform-es2015-spread": "^6.22.0",
+                "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+                "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+                "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+                "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+                "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+                "babel-plugin-transform-regenerator": "^6.22.0",
+                "browserslist": "^3.2.6",
+                "invariant": "^2.2.2",
+                "semver": "^5.3.0"
             },
             "dependencies": {
                 "browserslist": {
@@ -1290,8 +1290,8 @@
                     "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
                     "dev": true,
                     "requires": {
-                        "caniuse-lite": "1.0.30000963",
-                        "electron-to-chromium": "1.3.127"
+                        "caniuse-lite": "^1.0.30000844",
+                        "electron-to-chromium": "^1.3.47"
                     }
                 },
                 "electron-to-chromium": {
@@ -1308,13 +1308,13 @@
             "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
             "dev": true,
             "requires": {
-                "babel-core": "6.26.3",
-                "babel-runtime": "6.26.0",
-                "core-js": "2.5.1",
-                "home-or-tmp": "2.0.0",
-                "lodash": "4.17.11",
-                "mkdirp": "0.5.1",
-                "source-map-support": "0.4.18"
+                "babel-core": "^6.26.0",
+                "babel-runtime": "^6.26.0",
+                "core-js": "^2.5.0",
+                "home-or-tmp": "^2.0.0",
+                "lodash": "^4.17.4",
+                "mkdirp": "^0.5.1",
+                "source-map-support": "^0.4.15"
             },
             "dependencies": {
                 "lodash": {
@@ -1330,8 +1330,8 @@
             "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
             "requires": {
-                "core-js": "2.5.1",
-                "regenerator-runtime": "0.11.0"
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
             },
             "dependencies": {
                 "regenerator-runtime": {
@@ -1347,11 +1347,11 @@
             "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "lodash": "4.17.11"
+                "babel-runtime": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "lodash": "^4.17.4"
             },
             "dependencies": {
                 "lodash": {
@@ -1368,15 +1368,15 @@
             "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "debug": "2.6.9",
-                "globals": "9.18.0",
-                "invariant": "2.2.4",
-                "lodash": "4.17.11"
+                "babel-code-frame": "^6.26.0",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "debug": "^2.6.8",
+                "globals": "^9.18.0",
+                "invariant": "^2.2.2",
+                "lodash": "^4.17.4"
             },
             "dependencies": {
                 "debug": {
@@ -1408,10 +1408,10 @@
             "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "esutils": "2.0.2",
-                "lodash": "4.17.11",
-                "to-fast-properties": "1.0.3"
+                "babel-runtime": "^6.26.0",
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.4",
+                "to-fast-properties": "^1.0.3"
             },
             "dependencies": {
                 "lodash": {
@@ -1471,7 +1471,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "benchmark": {
@@ -1513,7 +1513,7 @@
             "integrity": "sha512-KE8NFMZr3mN2E0HcvCgRtX7DjhiIQrwle+nSVJVC/yqFb9+xznHl2ZcoBp2L9qzkI4t4cBFJ1efXF8Dwi132RA==",
             "dev": true,
             "requires": {
-                "minimist": "1.2.0"
+                "minimist": "^1.2.0"
             },
             "dependencies": {
                 "minimist": {
@@ -1543,15 +1543,15 @@
             "dev": true,
             "requires": {
                 "bytes": "3.0.0",
-                "content-type": "1.0.4",
+                "content-type": "~1.0.4",
                 "debug": "2.6.9",
-                "depd": "1.1.1",
-                "http-errors": "1.6.2",
+                "depd": "~1.1.1",
+                "http-errors": "~1.6.2",
                 "iconv-lite": "0.4.19",
-                "on-finished": "2.3.0",
+                "on-finished": "~2.3.0",
                 "qs": "6.5.1",
                 "raw-body": "2.3.2",
-                "type-is": "1.6.15"
+                "type-is": "~1.6.15"
             },
             "dependencies": {
                 "debug": {
@@ -1583,7 +1583,7 @@
             "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
             "dev": true,
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
             }
         },
         "bootstrap": {
@@ -1597,7 +1597,7 @@
             "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
             "dev": true,
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -1607,9 +1607,9 @@
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
             "dev": true,
             "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
             }
         },
         "brorand": {
@@ -1624,12 +1624,12 @@
             "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
             "dev": true,
             "requires": {
-                "buffer-xor": "1.0.3",
-                "cipher-base": "1.0.4",
-                "create-hash": "1.1.3",
-                "evp_bytestokey": "1.0.3",
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.1"
+                "buffer-xor": "^1.0.3",
+                "cipher-base": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.3",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "browserify-cipher": {
@@ -1638,9 +1638,9 @@
             "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
             "dev": true,
             "requires": {
-                "browserify-aes": "1.1.1",
-                "browserify-des": "1.0.0",
-                "evp_bytestokey": "1.0.3"
+                "browserify-aes": "^1.0.4",
+                "browserify-des": "^1.0.0",
+                "evp_bytestokey": "^1.0.0"
             }
         },
         "browserify-des": {
@@ -1649,9 +1649,9 @@
             "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
             "dev": true,
             "requires": {
-                "cipher-base": "1.0.4",
-                "des.js": "1.0.0",
-                "inherits": "2.0.3"
+                "cipher-base": "^1.0.1",
+                "des.js": "^1.0.0",
+                "inherits": "^2.0.1"
             }
         },
         "browserify-rsa": {
@@ -1660,8 +1660,8 @@
             "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "randombytes": "2.0.5"
+                "bn.js": "^4.1.0",
+                "randombytes": "^2.0.1"
             }
         },
         "browserify-sign": {
@@ -1670,13 +1670,13 @@
             "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "browserify-rsa": "4.0.1",
-                "create-hash": "1.1.3",
-                "create-hmac": "1.1.6",
-                "elliptic": "6.4.0",
-                "inherits": "2.0.3",
-                "parse-asn1": "5.1.0"
+                "bn.js": "^4.1.1",
+                "browserify-rsa": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "create-hmac": "^1.1.2",
+                "elliptic": "^6.0.0",
+                "inherits": "^2.0.1",
+                "parse-asn1": "^5.0.0"
             }
         },
         "browserify-zlib": {
@@ -1685,7 +1685,7 @@
             "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
             "dev": true,
             "requires": {
-                "pako": "1.0.6"
+                "pako": "~1.0.5"
             }
         },
         "browserslist": {
@@ -1694,8 +1694,8 @@
             "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
             "dev": true,
             "requires": {
-                "caniuse-db": "1.0.30000772",
-                "electron-to-chromium": "1.3.27"
+                "caniuse-db": "^1.0.30000639",
+                "electron-to-chromium": "^1.2.7"
             }
         },
         "buffer": {
@@ -1704,9 +1704,9 @@
             "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
             "dev": true,
             "requires": {
-                "base64-js": "1.2.1",
-                "ieee754": "1.1.8",
-                "isarray": "1.0.0"
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
             },
             "dependencies": {
                 "isarray": {
@@ -1747,7 +1747,7 @@
             "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
             "dev": true,
             "requires": {
-                "callsites": "0.2.0"
+                "callsites": "^0.2.0"
             }
         },
         "callsite": {
@@ -1768,8 +1768,8 @@
             "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
             "dev": true,
             "requires": {
-                "no-case": "2.3.2",
-                "upper-case": "1.1.3"
+                "no-case": "^2.2.0",
+                "upper-case": "^1.1.1"
             }
         },
         "camelcase": {
@@ -1784,10 +1784,10 @@
             "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
             "dev": true,
             "requires": {
-                "browserslist": "1.7.7",
-                "caniuse-db": "1.0.30000772",
-                "lodash.memoize": "4.1.2",
-                "lodash.uniq": "4.5.0"
+                "browserslist": "^1.3.6",
+                "caniuse-db": "^1.0.30000529",
+                "lodash.memoize": "^4.1.2",
+                "lodash.uniq": "^4.5.0"
             }
         },
         "caniuse-db": {
@@ -1814,8 +1814,8 @@
             "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
             "dev": true,
             "requires": {
-                "align-text": "0.1.4",
-                "lazy-cache": "1.0.4"
+                "align-text": "^0.1.3",
+                "lazy-cache": "^1.0.3"
             }
         },
         "chalk": {
@@ -1824,11 +1824,11 @@
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "dev": true,
             "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
             }
         },
         "chokidar": {
@@ -1837,15 +1837,15 @@
             "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
             "dev": true,
             "requires": {
-                "anymatch": "1.3.2",
-                "async-each": "1.0.1",
-                "fsevents": "1.1.3",
-                "glob-parent": "2.0.0",
-                "inherits": "2.0.3",
-                "is-binary-path": "1.0.1",
-                "is-glob": "2.0.1",
-                "path-is-absolute": "1.0.1",
-                "readdirp": "2.1.0"
+                "anymatch": "^1.3.0",
+                "async-each": "^1.0.0",
+                "fsevents": "^1.0.0",
+                "glob-parent": "^2.0.0",
+                "inherits": "^2.0.1",
+                "is-binary-path": "^1.0.0",
+                "is-glob": "^2.0.0",
+                "path-is-absolute": "^1.0.0",
+                "readdirp": "^2.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -1860,7 +1860,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -1871,8 +1871,8 @@
             "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.1"
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "circular-json": {
@@ -1887,7 +1887,7 @@
             "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3"
+                "chalk": "^1.1.3"
             }
         },
         "clean-css": {
@@ -1896,7 +1896,7 @@
             "integrity": "sha1-Nc7ornaHpJuYA09w3gDE7dOCYwE=",
             "dev": true,
             "requires": {
-                "source-map": "0.5.7"
+                "source-map": "0.5.x"
             }
         },
         "cli": {
@@ -1906,7 +1906,7 @@
             "dev": true,
             "requires": {
                 "exit": "0.1.2",
-                "glob": "7.1.2"
+                "glob": "^7.1.1"
             }
         },
         "cli-cursor": {
@@ -1915,7 +1915,7 @@
             "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
             "dev": true,
             "requires": {
-                "restore-cursor": "2.0.0"
+                "restore-cursor": "^2.0.0"
             }
         },
         "cli-width": {
@@ -1930,8 +1930,8 @@
             "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
             "dev": true,
             "requires": {
-                "center-align": "0.1.3",
-                "right-align": "0.1.3",
+                "center-align": "^0.1.1",
+                "right-align": "^0.1.1",
                 "wordwrap": "0.0.2"
             },
             "dependencies": {
@@ -1960,7 +1960,7 @@
             "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
             "dev": true,
             "requires": {
-                "q": "1.4.1"
+                "q": "^1.1.2"
             }
         },
         "code-point-at": {
@@ -1975,9 +1975,9 @@
             "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
             "dev": true,
             "requires": {
-                "clone": "1.0.3",
-                "color-convert": "1.9.0",
-                "color-string": "0.3.0"
+                "clone": "^1.0.2",
+                "color-convert": "^1.3.0",
+                "color-string": "^0.3.0"
             }
         },
         "color-convert": {
@@ -1986,7 +1986,7 @@
             "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
             "dev": true,
             "requires": {
-                "color-name": "1.1.3"
+                "color-name": "^1.1.1"
             }
         },
         "color-name": {
@@ -2001,7 +2001,7 @@
             "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
             "dev": true,
             "requires": {
-                "color-name": "1.1.3"
+                "color-name": "^1.0.0"
             }
         },
         "colormin": {
@@ -2010,9 +2010,9 @@
             "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
             "dev": true,
             "requires": {
-                "color": "0.11.4",
+                "color": "^0.11.0",
                 "css-color-names": "0.0.4",
-                "has": "1.0.1"
+                "has": "^1.0.1"
             }
         },
         "colors": {
@@ -2027,7 +2027,7 @@
             "integrity": "sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=",
             "dev": true,
             "requires": {
-                "lodash": "4.12.0"
+                "lodash": "^4.5.0"
             }
         },
         "combined-stream": {
@@ -2036,7 +2036,7 @@
             "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
             "dev": true,
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
@@ -2075,7 +2075,7 @@
             "integrity": "sha1-xZpcmdt2dn6YdlAOJx72OzSTvWY=",
             "dev": true,
             "requires": {
-                "mime-db": "1.30.0"
+                "mime-db": ">= 1.30.0 < 2"
             }
         },
         "compression": {
@@ -2084,13 +2084,13 @@
             "integrity": "sha1-7/JgPvwuIs+G810uuTWJ+YdTc9s=",
             "dev": true,
             "requires": {
-                "accepts": "1.3.4",
+                "accepts": "~1.3.4",
                 "bytes": "3.0.0",
-                "compressible": "2.0.12",
+                "compressible": "~2.0.11",
                 "debug": "2.6.9",
-                "on-headers": "1.0.1",
+                "on-headers": "~1.0.1",
                 "safe-buffer": "5.1.1",
-                "vary": "1.1.2"
+                "vary": "~1.1.2"
             },
             "dependencies": {
                 "accepts": {
@@ -2099,7 +2099,7 @@
                     "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
                     "dev": true,
                     "requires": {
-                        "mime-types": "2.1.17",
+                        "mime-types": "~2.1.16",
                         "negotiator": "0.6.1"
                     }
                 },
@@ -2138,9 +2138,9 @@
             "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3",
-                "typedarray": "0.0.6"
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
             },
             "dependencies": {
                 "isarray": {
@@ -2155,13 +2155,13 @@
                     "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.0.3",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.0.3",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -2170,7 +2170,7 @@
                     "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -2183,7 +2183,7 @@
             "requires": {
                 "debug": "2.6.9",
                 "finalhandler": "1.0.6",
-                "parseurl": "1.3.2",
+                "parseurl": "~1.3.2",
                 "utils-merge": "1.0.1"
             },
             "dependencies": {
@@ -2216,7 +2216,7 @@
             "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
             "dev": true,
             "requires": {
-                "date-now": "0.1.4"
+                "date-now": "^0.1.4"
             }
         },
         "constants-browserify": {
@@ -2243,7 +2243,7 @@
             "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "~5.1.1"
             }
         },
         "cookie": {
@@ -2264,14 +2264,14 @@
             "integrity": "sha1-U65p4ElV6/qf2kEfVMu5aFMdcf0=",
             "dev": true,
             "requires": {
-                "bluebird": "3.5.1",
-                "fs-extra": "4.0.2",
-                "glob": "7.1.2",
-                "is-glob": "4.0.0",
-                "loader-utils": "0.2.17",
-                "lodash": "4.12.0",
-                "minimatch": "3.0.4",
-                "node-dir": "0.1.17"
+                "bluebird": "^3.5.1",
+                "fs-extra": "^4.0.2",
+                "glob": "^7.1.2",
+                "is-glob": "^4.0.0",
+                "loader-utils": "^0.2.15",
+                "lodash": "^4.3.0",
+                "minimatch": "^3.0.4",
+                "node-dir": "^0.1.10"
             },
             "dependencies": {
                 "fs-extra": {
@@ -2280,9 +2280,9 @@
                     "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.3",
-                        "jsonfile": "4.0.0",
-                        "universalify": "0.1.1"
+                        "graceful-fs": "^4.1.2",
+                        "jsonfile": "^4.0.0",
+                        "universalify": "^0.1.0"
                     }
                 },
                 "jsonfile": {
@@ -2291,7 +2291,7 @@
                     "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11"
+                        "graceful-fs": "^4.1.6"
                     },
                     "dependencies": {
                         "graceful-fs": {
@@ -2322,8 +2322,8 @@
             "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "elliptic": "6.4.0"
+                "bn.js": "^4.1.0",
+                "elliptic": "^6.0.0"
             }
         },
         "create-hash": {
@@ -2332,10 +2332,10 @@
             "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
             "dev": true,
             "requires": {
-                "cipher-base": "1.0.4",
-                "inherits": "2.0.3",
-                "ripemd160": "2.0.1",
-                "sha.js": "2.4.9"
+                "cipher-base": "^1.0.1",
+                "inherits": "^2.0.1",
+                "ripemd160": "^2.0.0",
+                "sha.js": "^2.4.0"
             }
         },
         "create-hmac": {
@@ -2344,12 +2344,12 @@
             "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
             "dev": true,
             "requires": {
-                "cipher-base": "1.0.4",
-                "create-hash": "1.1.3",
-                "inherits": "2.0.3",
-                "ripemd160": "2.0.1",
-                "safe-buffer": "5.1.1",
-                "sha.js": "2.4.9"
+                "cipher-base": "^1.0.3",
+                "create-hash": "^1.1.0",
+                "inherits": "^2.0.1",
+                "ripemd160": "^2.0.0",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
             }
         },
         "cross-spawn": {
@@ -2358,9 +2358,9 @@
             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
             "dev": true,
             "requires": {
-                "lru-cache": "4.1.1",
-                "shebang-command": "1.2.0",
-                "which": "1.3.0"
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
             },
             "dependencies": {
                 "lru-cache": {
@@ -2369,8 +2369,8 @@
                     "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
                     "dev": true,
                     "requires": {
-                        "pseudomap": "1.0.2",
-                        "yallist": "2.1.2"
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
                     }
                 }
             }
@@ -2381,7 +2381,7 @@
             "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
             "dev": true,
             "requires": {
-                "boom": "2.10.1"
+                "boom": "2.x.x"
             }
         },
         "crypto-browserify": {
@@ -2390,17 +2390,17 @@
             "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
             "dev": true,
             "requires": {
-                "browserify-cipher": "1.0.0",
-                "browserify-sign": "4.0.4",
-                "create-ecdh": "4.0.0",
-                "create-hash": "1.1.3",
-                "create-hmac": "1.1.6",
-                "diffie-hellman": "5.0.2",
-                "inherits": "2.0.3",
-                "pbkdf2": "3.0.14",
-                "public-encrypt": "4.0.0",
-                "randombytes": "2.0.5",
-                "randomfill": "1.0.3"
+                "browserify-cipher": "^1.0.0",
+                "browserify-sign": "^4.0.0",
+                "create-ecdh": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "create-hmac": "^1.1.0",
+                "diffie-hellman": "^5.0.0",
+                "inherits": "^2.0.1",
+                "pbkdf2": "^3.0.3",
+                "public-encrypt": "^4.0.0",
+                "randombytes": "^2.0.0",
+                "randomfill": "^1.0.3"
             }
         },
         "css-color-names": {
@@ -2415,19 +2415,19 @@
             "integrity": "sha1-IgMlWZ+PAEUtnOtMPKbIpmeYZC0=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "css-selector-tokenizer": "0.7.0",
-                "cssnano": "3.10.0",
-                "loader-utils": "1.1.0",
-                "lodash.camelcase": "4.3.0",
-                "object-assign": "4.1.1",
-                "postcss": "5.2.18",
-                "postcss-modules-extract-imports": "1.1.0",
-                "postcss-modules-local-by-default": "1.2.0",
-                "postcss-modules-scope": "1.1.0",
-                "postcss-modules-values": "1.3.0",
-                "postcss-value-parser": "3.3.0",
-                "source-list-map": "0.1.8"
+                "babel-code-frame": "^6.11.0",
+                "css-selector-tokenizer": "^0.7.0",
+                "cssnano": ">=2.6.1 <4",
+                "loader-utils": "^1.0.2",
+                "lodash.camelcase": "^4.3.0",
+                "object-assign": "^4.0.1",
+                "postcss": "^5.0.6",
+                "postcss-modules-extract-imports": "^1.0.0",
+                "postcss-modules-local-by-default": "^1.0.1",
+                "postcss-modules-scope": "^1.0.0",
+                "postcss-modules-values": "^1.1.0",
+                "postcss-value-parser": "^3.3.0",
+                "source-list-map": "^0.1.7"
             },
             "dependencies": {
                 "loader-utils": {
@@ -2436,9 +2436,9 @@
                     "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
                     "dev": true,
                     "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1"
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0"
                     }
                 }
             }
@@ -2449,10 +2449,10 @@
             "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
             "dev": true,
             "requires": {
-                "boolbase": "1.0.0",
-                "css-what": "2.1.0",
+                "boolbase": "~1.0.0",
+                "css-what": "2.1",
                 "domutils": "1.5.1",
-                "nth-check": "1.0.1"
+                "nth-check": "~1.0.1"
             }
         },
         "css-selector-tokenizer": {
@@ -2461,9 +2461,9 @@
             "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
             "dev": true,
             "requires": {
-                "cssesc": "0.1.0",
-                "fastparse": "1.1.1",
-                "regexpu-core": "1.0.0"
+                "cssesc": "^0.1.0",
+                "fastparse": "^1.1.1",
+                "regexpu-core": "^1.0.0"
             }
         },
         "css-what": {
@@ -2484,38 +2484,38 @@
             "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
             "dev": true,
             "requires": {
-                "autoprefixer": "6.7.7",
-                "decamelize": "1.2.0",
-                "defined": "1.0.0",
-                "has": "1.0.1",
-                "object-assign": "4.1.1",
-                "postcss": "5.2.18",
-                "postcss-calc": "5.3.1",
-                "postcss-colormin": "2.2.2",
-                "postcss-convert-values": "2.6.1",
-                "postcss-discard-comments": "2.0.4",
-                "postcss-discard-duplicates": "2.1.0",
-                "postcss-discard-empty": "2.1.0",
-                "postcss-discard-overridden": "0.1.1",
-                "postcss-discard-unused": "2.2.3",
-                "postcss-filter-plugins": "2.0.2",
-                "postcss-merge-idents": "2.1.7",
-                "postcss-merge-longhand": "2.0.2",
-                "postcss-merge-rules": "2.1.2",
-                "postcss-minify-font-values": "1.0.5",
-                "postcss-minify-gradients": "1.0.5",
-                "postcss-minify-params": "1.2.2",
-                "postcss-minify-selectors": "2.1.1",
-                "postcss-normalize-charset": "1.1.1",
-                "postcss-normalize-url": "3.0.8",
-                "postcss-ordered-values": "2.2.3",
-                "postcss-reduce-idents": "2.4.0",
-                "postcss-reduce-initial": "1.0.1",
-                "postcss-reduce-transforms": "1.0.4",
-                "postcss-svgo": "2.1.6",
-                "postcss-unique-selectors": "2.0.2",
-                "postcss-value-parser": "3.3.0",
-                "postcss-zindex": "2.2.0"
+                "autoprefixer": "^6.3.1",
+                "decamelize": "^1.1.2",
+                "defined": "^1.0.0",
+                "has": "^1.0.1",
+                "object-assign": "^4.0.1",
+                "postcss": "^5.0.14",
+                "postcss-calc": "^5.2.0",
+                "postcss-colormin": "^2.1.8",
+                "postcss-convert-values": "^2.3.4",
+                "postcss-discard-comments": "^2.0.4",
+                "postcss-discard-duplicates": "^2.0.1",
+                "postcss-discard-empty": "^2.0.1",
+                "postcss-discard-overridden": "^0.1.1",
+                "postcss-discard-unused": "^2.2.1",
+                "postcss-filter-plugins": "^2.0.0",
+                "postcss-merge-idents": "^2.1.5",
+                "postcss-merge-longhand": "^2.0.1",
+                "postcss-merge-rules": "^2.0.3",
+                "postcss-minify-font-values": "^1.0.2",
+                "postcss-minify-gradients": "^1.0.1",
+                "postcss-minify-params": "^1.0.4",
+                "postcss-minify-selectors": "^2.0.4",
+                "postcss-normalize-charset": "^1.1.0",
+                "postcss-normalize-url": "^3.0.7",
+                "postcss-ordered-values": "^2.1.0",
+                "postcss-reduce-idents": "^2.2.2",
+                "postcss-reduce-initial": "^1.0.0",
+                "postcss-reduce-transforms": "^1.0.3",
+                "postcss-svgo": "^2.1.1",
+                "postcss-unique-selectors": "^2.0.2",
+                "postcss-value-parser": "^3.2.3",
+                "postcss-zindex": "^2.0.1"
             }
         },
         "csso": {
@@ -2524,8 +2524,8 @@
             "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
             "dev": true,
             "requires": {
-                "clap": "1.2.3",
-                "source-map": "0.5.7"
+                "clap": "^1.0.9",
+                "source-map": "^0.5.3"
             }
         },
         "custom-event": {
@@ -2540,7 +2540,7 @@
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -2590,13 +2590,13 @@
             "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
             "dev": true,
             "requires": {
-                "globby": "5.0.0",
-                "is-path-cwd": "1.0.0",
-                "is-path-in-cwd": "1.0.0",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "rimraf": "2.6.2"
+                "globby": "^5.0.0",
+                "is-path-cwd": "^1.0.0",
+                "is-path-in-cwd": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "rimraf": "^2.2.8"
             }
         },
         "delayed-stream": {
@@ -2617,8 +2617,8 @@
             "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.0"
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "destroy": {
@@ -2633,7 +2633,7 @@
             "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
             "dev": true,
             "requires": {
-                "repeating": "2.0.1"
+                "repeating": "^2.0.0"
             }
         },
         "detect-node": {
@@ -2660,9 +2660,9 @@
             "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "miller-rabin": "4.0.1",
-                "randombytes": "2.0.5"
+                "bn.js": "^4.1.0",
+                "miller-rabin": "^4.0.0",
+                "randombytes": "^2.0.0"
             }
         },
         "doctrine": {
@@ -2671,8 +2671,8 @@
             "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
             "dev": true,
             "requires": {
-                "esutils": "2.0.2",
-                "isarray": "1.0.0"
+                "esutils": "^2.0.2",
+                "isarray": "^1.0.0"
             },
             "dependencies": {
                 "isarray": {
@@ -2689,7 +2689,7 @@
             "integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
             "dev": true,
             "requires": {
-                "utila": "0.3.3"
+                "utila": "~0.3"
             },
             "dependencies": {
                 "utila": {
@@ -2706,10 +2706,10 @@
             "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
             "dev": true,
             "requires": {
-                "custom-event": "1.0.1",
-                "ent": "2.2.0",
-                "extend": "3.0.1",
-                "void-elements": "2.0.1"
+                "custom-event": "~1.0.0",
+                "ent": "~2.2.0",
+                "extend": "^3.0.0",
+                "void-elements": "^2.0.0"
             }
         },
         "dom-serializer": {
@@ -2718,8 +2718,8 @@
             "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.1.3",
-                "entities": "1.1.1"
+                "domelementtype": "~1.1.1",
+                "entities": "~1.1.1"
             },
             "dependencies": {
                 "domelementtype": {
@@ -2754,7 +2754,7 @@
             "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.0"
+                "domelementtype": "1"
             }
         },
         "domutils": {
@@ -2763,8 +2763,8 @@
             "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
             "dev": true,
             "requires": {
-                "dom-serializer": "0.1.0",
-                "domelementtype": "1.3.0"
+                "dom-serializer": "0",
+                "domelementtype": "1"
             }
         },
         "ecc-jsbn": {
@@ -2774,7 +2774,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "jsbn": "0.1.1"
+                "jsbn": "~0.1.0"
             }
         },
         "ee-first": {
@@ -2795,13 +2795,13 @@
             "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "brorand": "1.1.0",
-                "hash.js": "1.1.3",
-                "hmac-drbg": "1.0.1",
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.0",
-                "minimalistic-crypto-utils": "1.0.1"
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
             }
         },
         "emojis-list": {
@@ -2835,8 +2835,8 @@
                     "integrity": "sha1-fQsqLljN3YGQOcKcneZQReGzEOk=",
                     "dev": true,
                     "requires": {
-                        "options": "0.0.6",
-                        "ultron": "1.0.2"
+                        "options": ">=0.0.5",
+                        "ultron": "1.0.x"
                     }
                 }
             }
@@ -2867,8 +2867,8 @@
                     "integrity": "sha1-fQsqLljN3YGQOcKcneZQReGzEOk=",
                     "dev": true,
                     "requires": {
-                        "options": "0.0.6",
-                        "ultron": "1.0.2"
+                        "options": ">=0.0.5",
+                        "ultron": "1.0.x"
                     }
                 }
             }
@@ -2904,10 +2904,10 @@
             "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.3",
-                "memory-fs": "0.4.1",
-                "object-assign": "4.1.1",
-                "tapable": "0.2.8"
+                "graceful-fs": "^4.1.2",
+                "memory-fs": "^0.4.0",
+                "object-assign": "^4.0.1",
+                "tapable": "^0.2.7"
             }
         },
         "ent": {
@@ -2928,7 +2928,7 @@
             "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
             "dev": true,
             "requires": {
-                "prr": "0.0.0"
+                "prr": "~0.0.0"
             }
         },
         "error-ex": {
@@ -2937,7 +2937,7 @@
             "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
             "dev": true,
             "requires": {
-                "is-arrayish": "0.2.1"
+                "is-arrayish": "^0.2.1"
             }
         },
         "es6-promise": {
@@ -2952,7 +2952,7 @@
             "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
             "dev": true,
             "requires": {
-                "es6-promise": "4.1.1"
+                "es6-promise": "^4.0.3"
             }
         },
         "escape-html": {
@@ -2973,43 +2973,43 @@
             "integrity": "sha1-8l0NeVXIGWjCMJqlyaIp4EUXa7c=",
             "dev": true,
             "requires": {
-                "ajv": "5.3.0",
-                "babel-code-frame": "6.26.0",
-                "chalk": "2.3.0",
-                "concat-stream": "1.6.0",
-                "cross-spawn": "5.1.0",
-                "debug": "3.1.0",
-                "doctrine": "2.0.0",
-                "eslint-scope": "3.7.1",
-                "espree": "3.5.1",
-                "esquery": "1.0.0",
-                "estraverse": "4.2.0",
-                "esutils": "2.0.2",
-                "file-entry-cache": "2.0.0",
-                "functional-red-black-tree": "1.0.1",
-                "glob": "7.1.2",
-                "globals": "9.18.0",
-                "ignore": "3.3.7",
-                "imurmurhash": "0.1.4",
-                "inquirer": "3.3.0",
-                "is-resolvable": "1.0.0",
-                "js-yaml": "3.10.0",
-                "json-stable-stringify": "1.0.1",
-                "levn": "0.3.0",
-                "lodash": "4.17.4",
-                "minimatch": "3.0.4",
-                "mkdirp": "0.5.1",
-                "natural-compare": "1.4.0",
-                "optionator": "0.8.2",
-                "path-is-inside": "1.0.2",
-                "pluralize": "7.0.0",
-                "progress": "2.0.0",
-                "require-uncached": "1.0.3",
-                "semver": "5.4.1",
-                "strip-ansi": "4.0.0",
-                "strip-json-comments": "2.0.1",
-                "table": "4.0.2",
-                "text-table": "0.2.0"
+                "ajv": "^5.2.0",
+                "babel-code-frame": "^6.22.0",
+                "chalk": "^2.1.0",
+                "concat-stream": "^1.6.0",
+                "cross-spawn": "^5.1.0",
+                "debug": "^3.0.1",
+                "doctrine": "^2.0.0",
+                "eslint-scope": "^3.7.1",
+                "espree": "^3.5.1",
+                "esquery": "^1.0.0",
+                "estraverse": "^4.2.0",
+                "esutils": "^2.0.2",
+                "file-entry-cache": "^2.0.0",
+                "functional-red-black-tree": "^1.0.1",
+                "glob": "^7.1.2",
+                "globals": "^9.17.0",
+                "ignore": "^3.3.3",
+                "imurmurhash": "^0.1.4",
+                "inquirer": "^3.0.6",
+                "is-resolvable": "^1.0.0",
+                "js-yaml": "^3.9.1",
+                "json-stable-stringify": "^1.0.1",
+                "levn": "^0.3.0",
+                "lodash": "^4.17.4",
+                "minimatch": "^3.0.2",
+                "mkdirp": "^0.5.1",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.8.2",
+                "path-is-inside": "^1.0.2",
+                "pluralize": "^7.0.0",
+                "progress": "^2.0.0",
+                "require-uncached": "^1.0.3",
+                "semver": "^5.3.0",
+                "strip-ansi": "^4.0.0",
+                "strip-json-comments": "~2.0.1",
+                "table": "^4.0.1",
+                "text-table": "~0.2.0"
             },
             "dependencies": {
                 "ajv": {
@@ -3018,10 +3018,10 @@
                     "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
                     "dev": true,
                     "requires": {
-                        "co": "4.6.0",
-                        "fast-deep-equal": "1.0.0",
-                        "fast-json-stable-stringify": "2.0.0",
-                        "json-schema-traverse": "0.3.1"
+                        "co": "^4.6.0",
+                        "fast-deep-equal": "^1.0.0",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.3.0"
                     }
                 },
                 "ansi-regex": {
@@ -3036,7 +3036,7 @@
                     "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.0"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -3045,9 +3045,9 @@
                     "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.0",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "4.5.0"
+                        "ansi-styles": "^3.1.0",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^4.0.0"
                     }
                 },
                 "debug": {
@@ -3083,7 +3083,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 },
                 "strip-json-comments": {
@@ -3098,7 +3098,7 @@
                     "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -3109,8 +3109,8 @@
             "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
             "dev": true,
             "requires": {
-                "esrecurse": "4.2.0",
-                "estraverse": "4.2.0"
+                "esrecurse": "^4.1.0",
+                "estraverse": "^4.1.1"
             }
         },
         "espree": {
@@ -3119,8 +3119,8 @@
             "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
             "dev": true,
             "requires": {
-                "acorn": "5.2.1",
-                "acorn-jsx": "3.0.1"
+                "acorn": "^5.1.1",
+                "acorn-jsx": "^3.0.0"
             }
         },
         "esprima": {
@@ -3135,7 +3135,7 @@
             "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
             "dev": true,
             "requires": {
-                "estraverse": "4.2.0"
+                "estraverse": "^4.0.0"
             }
         },
         "esrecurse": {
@@ -3144,8 +3144,8 @@
             "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
             "dev": true,
             "requires": {
-                "estraverse": "4.2.0",
-                "object-assign": "4.1.1"
+                "estraverse": "^4.1.0",
+                "object-assign": "^4.0.1"
             }
         },
         "estraverse": {
@@ -3184,7 +3184,7 @@
             "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
             "dev": true,
             "requires": {
-                "original": "1.0.0"
+                "original": ">=0.0.5"
             }
         },
         "evp_bytestokey": {
@@ -3193,8 +3193,8 @@
             "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
             "dev": true,
             "requires": {
-                "md5.js": "1.3.4",
-                "safe-buffer": "5.1.1"
+                "md5.js": "^1.3.4",
+                "safe-buffer": "^5.1.1"
             }
         },
         "exit": {
@@ -3209,9 +3209,9 @@
             "integrity": "sha1-SIsdHSRRyz06axks/AMPRMWFX+o=",
             "dev": true,
             "requires": {
-                "array-slice": "0.2.3",
-                "array-unique": "0.2.1",
-                "braces": "0.1.5"
+                "array-slice": "^0.2.3",
+                "array-unique": "^0.2.1",
+                "braces": "^0.1.2"
             },
             "dependencies": {
                 "braces": {
@@ -3220,7 +3220,7 @@
                     "integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
                     "dev": true,
                     "requires": {
-                        "expand-range": "0.1.1"
+                        "expand-range": "^0.1.0"
                     }
                 },
                 "expand-range": {
@@ -3229,8 +3229,8 @@
                     "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
                     "dev": true,
                     "requires": {
-                        "is-number": "0.1.1",
-                        "repeat-string": "0.2.2"
+                        "is-number": "^0.1.1",
+                        "repeat-string": "^0.2.2"
                     }
                 },
                 "is-number": {
@@ -3253,7 +3253,7 @@
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
             "dev": true,
             "requires": {
-                "is-posix-bracket": "0.1.1"
+                "is-posix-bracket": "^0.1.0"
             }
         },
         "expand-range": {
@@ -3262,7 +3262,7 @@
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
-                "fill-range": "2.2.3"
+                "fill-range": "^2.1.0"
             }
         },
         "express": {
@@ -3271,36 +3271,36 @@
             "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
             "dev": true,
             "requires": {
-                "accepts": "1.3.4",
+                "accepts": "~1.3.4",
                 "array-flatten": "1.1.1",
                 "body-parser": "1.18.2",
                 "content-disposition": "0.5.2",
-                "content-type": "1.0.4",
+                "content-type": "~1.0.4",
                 "cookie": "0.3.1",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
-                "depd": "1.1.1",
-                "encodeurl": "1.0.1",
-                "escape-html": "1.0.3",
-                "etag": "1.8.1",
+                "depd": "~1.1.1",
+                "encodeurl": "~1.0.1",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
                 "finalhandler": "1.1.0",
                 "fresh": "0.5.2",
                 "merge-descriptors": "1.0.1",
-                "methods": "1.1.2",
-                "on-finished": "2.3.0",
-                "parseurl": "1.3.2",
+                "methods": "~1.1.2",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.2",
                 "path-to-regexp": "0.1.7",
-                "proxy-addr": "2.0.2",
+                "proxy-addr": "~2.0.2",
                 "qs": "6.5.1",
-                "range-parser": "1.2.0",
+                "range-parser": "~1.2.0",
                 "safe-buffer": "5.1.1",
                 "send": "0.16.1",
                 "serve-static": "1.13.1",
                 "setprototypeof": "1.1.0",
-                "statuses": "1.3.1",
-                "type-is": "1.6.15",
+                "statuses": "~1.3.1",
+                "type-is": "~1.6.15",
                 "utils-merge": "1.0.1",
-                "vary": "1.1.2"
+                "vary": "~1.1.2"
             },
             "dependencies": {
                 "accepts": {
@@ -3309,7 +3309,7 @@
                     "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
                     "dev": true,
                     "requires": {
-                        "mime-types": "2.1.17",
+                        "mime-types": "~2.1.16",
                         "negotiator": "0.6.1"
                     }
                 },
@@ -3329,12 +3329,12 @@
                     "dev": true,
                     "requires": {
                         "debug": "2.6.9",
-                        "encodeurl": "1.0.1",
-                        "escape-html": "1.0.3",
-                        "on-finished": "2.3.0",
-                        "parseurl": "1.3.2",
-                        "statuses": "1.3.1",
-                        "unpipe": "1.0.0"
+                        "encodeurl": "~1.0.1",
+                        "escape-html": "~1.0.3",
+                        "on-finished": "~2.3.0",
+                        "parseurl": "~1.3.2",
+                        "statuses": "~1.3.1",
+                        "unpipe": "~1.0.0"
                     }
                 },
                 "ms": {
@@ -3375,9 +3375,9 @@
             "integrity": "sha1-UsJJo5gbm6GHx8rPW+tQvx2Rprw=",
             "dev": true,
             "requires": {
-                "iconv-lite": "0.4.19",
-                "jschardet": "1.6.0",
-                "tmp": "0.0.33"
+                "iconv-lite": "^0.4.17",
+                "jschardet": "^1.4.2",
+                "tmp": "^0.0.33"
             },
             "dependencies": {
                 "tmp": {
@@ -3386,7 +3386,7 @@
                     "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
                     "dev": true,
                     "requires": {
-                        "os-tmpdir": "1.0.2"
+                        "os-tmpdir": "~1.0.2"
                     }
                 }
             }
@@ -3397,7 +3397,7 @@
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
             "dev": true,
             "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -3442,7 +3442,7 @@
             "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
             "dev": true,
             "requires": {
-                "websocket-driver": "0.7.0"
+                "websocket-driver": ">=0.5.1"
             }
         },
         "figures": {
@@ -3451,7 +3451,7 @@
             "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
             "dev": true,
             "requires": {
-                "escape-string-regexp": "1.0.5"
+                "escape-string-regexp": "^1.0.5"
             }
         },
         "file-entry-cache": {
@@ -3460,8 +3460,8 @@
             "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
             "dev": true,
             "requires": {
-                "flat-cache": "1.3.0",
-                "object-assign": "4.1.1"
+                "flat-cache": "^1.2.1",
+                "object-assign": "^4.0.1"
             }
         },
         "file-loader": {
@@ -3470,7 +3470,7 @@
             "integrity": "sha1-azKO4SNKcp5OR9Njdd1tNcDh24Q=",
             "dev": true,
             "requires": {
-                "loader-utils": "1.1.0"
+                "loader-utils": "^1.0.2"
             },
             "dependencies": {
                 "loader-utils": {
@@ -3479,9 +3479,9 @@
                     "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
                     "dev": true,
                     "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1"
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0"
                     }
                 }
             }
@@ -3498,11 +3498,11 @@
             "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
             "dev": true,
             "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "1.1.7",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.6.1"
+                "is-number": "^2.1.0",
+                "isobject": "^2.0.0",
+                "randomatic": "^1.1.3",
+                "repeat-element": "^1.1.2",
+                "repeat-string": "^1.5.2"
             }
         },
         "finalhandler": {
@@ -3512,12 +3512,12 @@
             "dev": true,
             "requires": {
                 "debug": "2.6.9",
-                "encodeurl": "1.0.1",
-                "escape-html": "1.0.3",
-                "on-finished": "2.3.0",
-                "parseurl": "1.3.2",
-                "statuses": "1.3.1",
-                "unpipe": "1.0.0"
+                "encodeurl": "~1.0.1",
+                "escape-html": "~1.0.3",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.2",
+                "statuses": "~1.3.1",
+                "unpipe": "~1.0.0"
             },
             "dependencies": {
                 "debug": {
@@ -3549,9 +3549,9 @@
             "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
             "dev": true,
             "requires": {
-                "commondir": "1.0.1",
-                "make-dir": "1.3.0",
-                "pkg-dir": "2.0.0"
+                "commondir": "^1.0.1",
+                "make-dir": "^1.0.0",
+                "pkg-dir": "^2.0.0"
             }
         },
         "find-up": {
@@ -3560,8 +3560,8 @@
             "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
             "dev": true,
             "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "flat-cache": {
@@ -3570,10 +3570,10 @@
             "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
             "dev": true,
             "requires": {
-                "circular-json": "0.3.3",
-                "del": "2.2.2",
-                "graceful-fs": "4.1.3",
-                "write": "0.2.1"
+                "circular-json": "^0.3.1",
+                "del": "^2.0.2",
+                "graceful-fs": "^4.1.2",
+                "write": "^0.2.1"
             }
         },
         "flatten": {
@@ -3594,7 +3594,7 @@
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2"
+                "for-in": "^1.0.1"
             }
         },
         "forever-agent": {
@@ -3609,9 +3609,9 @@
             "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
             "dev": true,
             "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.6",
-                "mime-types": "2.1.17"
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.5",
+                "mime-types": "^2.1.12"
             }
         },
         "forwarded": {
@@ -3632,7 +3632,7 @@
             "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
             "dev": true,
             "requires": {
-                "null-check": "1.0.0"
+                "null-check": "^1.0.0"
             }
         },
         "fs.realpath": {
@@ -3648,8 +3648,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "nan": "2.8.0",
-                "node-pre-gyp": "0.6.39"
+                "nan": "^2.3.0",
+                "node-pre-gyp": "^0.6.39"
             },
             "dependencies": {
                 "abbrev": {
@@ -3664,8 +3664,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "co": "4.6.0",
-                        "json-stable-stringify": "1.0.1"
+                        "co": "^4.6.0",
+                        "json-stable-stringify": "^1.0.1"
                     }
                 },
                 "ansi-regex": {
@@ -3685,8 +3685,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "delegates": "1.0.0",
-                        "readable-stream": "2.2.9"
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
                     }
                 },
                 "asn1": {
@@ -3730,7 +3730,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "tweetnacl": "0.14.5"
+                        "tweetnacl": "^0.14.3"
                     }
                 },
                 "block-stream": {
@@ -3738,7 +3738,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.3"
+                        "inherits": "~2.0.0"
                     }
                 },
                 "boom": {
@@ -3746,7 +3746,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "hoek": "2.16.3"
+                        "hoek": "2.x.x"
                     }
                 },
                 "brace-expansion": {
@@ -3754,7 +3754,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "balanced-match": "0.4.2",
+                        "balanced-match": "^0.4.1",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -3785,7 +3785,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "delayed-stream": "1.0.0"
+                        "delayed-stream": "~1.0.0"
                     }
                 },
                 "concat-map": {
@@ -3808,7 +3808,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "boom": "2.10.1"
+                        "boom": "2.x.x"
                     }
                 },
                 "dashdash": {
@@ -3817,7 +3817,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "^1.0.0"
                     },
                     "dependencies": {
                         "assert-plus": {
@@ -3866,7 +3866,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "jsbn": "0.1.1"
+                        "jsbn": "~0.1.0"
                     }
                 },
                 "extend": {
@@ -3892,9 +3892,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "asynckit": "0.4.0",
-                        "combined-stream": "1.0.5",
-                        "mime-types": "2.1.15"
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.5",
+                        "mime-types": "^2.1.12"
                     }
                 },
                 "fs.realpath": {
@@ -3907,10 +3907,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "inherits": "2.0.3",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.6.1"
+                        "graceful-fs": "^4.1.2",
+                        "inherits": "~2.0.0",
+                        "mkdirp": ">=0.5 0",
+                        "rimraf": "2"
                     }
                 },
                 "fstream-ignore": {
@@ -3919,9 +3919,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "fstream": "1.0.11",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4"
+                        "fstream": "^1.0.0",
+                        "inherits": "2",
+                        "minimatch": "^3.0.0"
                     }
                 },
                 "gauge": {
@@ -3930,14 +3930,14 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "aproba": "1.1.1",
-                        "console-control-strings": "1.1.0",
-                        "has-unicode": "2.0.1",
-                        "object-assign": "4.1.1",
-                        "signal-exit": "3.0.2",
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wide-align": "1.1.2"
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
                     }
                 },
                 "getpass": {
@@ -3946,7 +3946,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "^1.0.0"
                     },
                     "dependencies": {
                         "assert-plus": {
@@ -3962,12 +3962,12 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "graceful-fs": {
@@ -3987,8 +3987,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "ajv": "4.11.8",
-                        "har-schema": "1.0.5"
+                        "ajv": "^4.9.1",
+                        "har-schema": "^1.0.5"
                     }
                 },
                 "has-unicode": {
@@ -4002,10 +4002,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "boom": "2.10.1",
-                        "cryptiles": "2.0.5",
-                        "hoek": "2.16.3",
-                        "sntp": "1.0.9"
+                        "boom": "2.x.x",
+                        "cryptiles": "2.x.x",
+                        "hoek": "2.x.x",
+                        "sntp": "1.x.x"
                     }
                 },
                 "hoek": {
@@ -4019,9 +4019,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "assert-plus": "0.2.0",
-                        "jsprim": "1.4.0",
-                        "sshpk": "1.13.0"
+                        "assert-plus": "^0.2.0",
+                        "jsprim": "^1.2.2",
+                        "sshpk": "^1.7.0"
                     }
                 },
                 "inflight": {
@@ -4029,8 +4029,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                     }
                 },
                 "inherits": {
@@ -4049,7 +4049,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "is-typedarray": {
@@ -4075,7 +4075,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "jsbn": "0.1.1"
+                        "jsbn": "~0.1.0"
                     }
                 },
                 "jsbn": {
@@ -4096,7 +4096,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "jsonify": "0.0.0"
+                        "jsonify": "~0.0.0"
                     }
                 },
                 "json-stringify-safe": {
@@ -4141,7 +4141,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "mime-db": "1.27.0"
+                        "mime-db": "~1.27.0"
                     }
                 },
                 "minimatch": {
@@ -4149,7 +4149,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "1.1.7"
+                        "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
@@ -4177,17 +4177,17 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "detect-libc": "1.0.2",
+                        "detect-libc": "^1.0.2",
                         "hawk": "3.1.3",
-                        "mkdirp": "0.5.1",
-                        "nopt": "4.0.1",
-                        "npmlog": "4.1.0",
-                        "rc": "1.2.1",
+                        "mkdirp": "^0.5.1",
+                        "nopt": "^4.0.1",
+                        "npmlog": "^4.0.2",
+                        "rc": "^1.1.7",
                         "request": "2.81.0",
-                        "rimraf": "2.6.1",
-                        "semver": "5.3.0",
-                        "tar": "2.2.1",
-                        "tar-pack": "3.4.0"
+                        "rimraf": "^2.6.1",
+                        "semver": "^5.3.0",
+                        "tar": "^2.2.1",
+                        "tar-pack": "^3.4.0"
                     }
                 },
                 "nopt": {
@@ -4196,8 +4196,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "abbrev": "1.1.0",
-                        "osenv": "0.1.4"
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
                     }
                 },
                 "npmlog": {
@@ -4206,10 +4206,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "are-we-there-yet": "1.1.4",
-                        "console-control-strings": "1.1.0",
-                        "gauge": "2.7.4",
-                        "set-blocking": "2.0.0"
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
                     }
                 },
                 "number-is-nan": {
@@ -4234,7 +4234,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 },
                 "os-homedir": {
@@ -4255,8 +4255,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "os-homedir": "1.0.2",
-                        "os-tmpdir": "1.0.2"
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
                     }
                 },
                 "path-is-absolute": {
@@ -4293,10 +4293,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "deep-extend": "0.4.2",
-                        "ini": "1.3.4",
-                        "minimist": "1.2.0",
-                        "strip-json-comments": "2.0.1"
+                        "deep-extend": "~0.4.0",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
                     },
                     "dependencies": {
                         "minimist": {
@@ -4312,13 +4312,13 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "buffer-shims": "1.0.0",
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "string_decoder": "1.0.1",
-                        "util-deprecate": "1.0.2"
+                        "buffer-shims": "~1.0.0",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "string_decoder": "~1.0.0",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "request": {
@@ -4327,28 +4327,28 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.12.0",
-                        "combined-stream": "1.0.5",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "4.2.1",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.15",
-                        "oauth-sign": "0.8.2",
-                        "performance-now": "0.2.0",
-                        "qs": "6.4.0",
-                        "safe-buffer": "5.0.1",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.2",
-                        "tunnel-agent": "0.6.0",
-                        "uuid": "3.0.1"
+                        "aws-sign2": "~0.6.0",
+                        "aws4": "^1.2.1",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.5",
+                        "extend": "~3.0.0",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.1.1",
+                        "har-validator": "~4.2.1",
+                        "hawk": "~3.1.3",
+                        "http-signature": "~1.1.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.7",
+                        "oauth-sign": "~0.8.1",
+                        "performance-now": "^0.2.0",
+                        "qs": "~6.4.0",
+                        "safe-buffer": "^5.0.1",
+                        "stringstream": "~0.0.4",
+                        "tough-cookie": "~2.3.0",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.0.0"
                     }
                 },
                 "rimraf": {
@@ -4356,7 +4356,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "glob": "7.1.2"
+                        "glob": "^7.0.5"
                     }
                 },
                 "safe-buffer": {
@@ -4387,7 +4387,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "hoek": "2.16.3"
+                        "hoek": "2.x.x"
                     }
                 },
                 "sshpk": {
@@ -4396,15 +4396,15 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "asn1": "0.2.3",
-                        "assert-plus": "1.0.0",
-                        "bcrypt-pbkdf": "1.0.1",
-                        "dashdash": "1.14.1",
-                        "ecc-jsbn": "0.1.1",
-                        "getpass": "0.1.7",
-                        "jodid25519": "1.0.2",
-                        "jsbn": "0.1.1",
-                        "tweetnacl": "0.14.5"
+                        "asn1": "~0.2.3",
+                        "assert-plus": "^1.0.0",
+                        "bcrypt-pbkdf": "^1.0.0",
+                        "dashdash": "^1.12.0",
+                        "ecc-jsbn": "~0.1.1",
+                        "getpass": "^0.1.1",
+                        "jodid25519": "^1.0.0",
+                        "jsbn": "~0.1.0",
+                        "tweetnacl": "~0.14.0"
                     },
                     "dependencies": {
                         "assert-plus": {
@@ -4420,9 +4420,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                     }
                 },
                 "string_decoder": {
@@ -4430,7 +4430,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.0.1"
+                        "safe-buffer": "^5.0.1"
                     }
                 },
                 "stringstream": {
@@ -4444,7 +4444,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "strip-json-comments": {
@@ -4458,9 +4458,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "block-stream": "0.0.9",
-                        "fstream": "1.0.11",
-                        "inherits": "2.0.3"
+                        "block-stream": "*",
+                        "fstream": "^1.0.2",
+                        "inherits": "2"
                     }
                 },
                 "tar-pack": {
@@ -4469,14 +4469,14 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "debug": "2.6.8",
-                        "fstream": "1.0.11",
-                        "fstream-ignore": "1.0.5",
-                        "once": "1.4.0",
-                        "readable-stream": "2.2.9",
-                        "rimraf": "2.6.1",
-                        "tar": "2.2.1",
-                        "uid-number": "0.0.6"
+                        "debug": "^2.2.0",
+                        "fstream": "^1.0.10",
+                        "fstream-ignore": "^1.0.5",
+                        "once": "^1.3.3",
+                        "readable-stream": "^2.1.4",
+                        "rimraf": "^2.5.1",
+                        "tar": "^2.2.1",
+                        "uid-number": "^0.0.6"
                     }
                 },
                 "tough-cookie": {
@@ -4485,7 +4485,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "punycode": "1.4.1"
+                        "punycode": "^1.4.1"
                     }
                 },
                 "tunnel-agent": {
@@ -4494,7 +4494,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safe-buffer": "5.0.1"
+                        "safe-buffer": "^5.0.1"
                     }
                 },
                 "tweetnacl": {
@@ -4535,7 +4535,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "string-width": "1.0.2"
+                        "string-width": "^1.0.2"
                     }
                 },
                 "wrappy": {
@@ -4563,7 +4563,7 @@
             "integrity": "sha1-PR8P4rXPeb8lOodd89ZwxjbbPgs=",
             "dev": true,
             "requires": {
-                "globule": "0.2.0"
+                "globule": "^0.2.0"
             }
         },
         "get-caller-file": {
@@ -4578,7 +4578,7 @@
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -4605,12 +4605,12 @@
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "dev": true,
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
@@ -4619,8 +4619,8 @@
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
             "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -4635,7 +4635,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -4646,7 +4646,7 @@
             "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
             "dev": true,
             "requires": {
-                "is-glob": "2.0.1"
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -4661,7 +4661,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -4678,12 +4678,12 @@
             "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
             "dev": true,
             "requires": {
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "glob": "7.1.2",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "glob": "^7.0.3",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "globule": {
@@ -4692,9 +4692,9 @@
             "integrity": "sha1-JrZNEOHtyrYJjY/gC9K3PMoIqPs=",
             "dev": true,
             "requires": {
-                "glob": "3.2.11",
-                "lodash": "2.4.2",
-                "minimatch": "0.2.14"
+                "glob": "~3.2.7",
+                "lodash": "~2.4.1",
+                "minimatch": "~0.2.11"
             },
             "dependencies": {
                 "glob": {
@@ -4703,8 +4703,8 @@
                     "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.3",
-                        "minimatch": "0.3.0"
+                        "inherits": "2",
+                        "minimatch": "0.3"
                     },
                     "dependencies": {
                         "minimatch": {
@@ -4713,8 +4713,8 @@
                             "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
                             "dev": true,
                             "requires": {
-                                "lru-cache": "2.7.3",
-                                "sigmund": "1.0.1"
+                                "lru-cache": "2",
+                                "sigmund": "~1.0.0"
                             }
                         }
                     }
@@ -4731,8 +4731,8 @@
                     "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "2.7.3",
-                        "sigmund": "1.0.1"
+                        "lru-cache": "2",
+                        "sigmund": "~1.0.0"
                     }
                 }
             }
@@ -4761,8 +4761,8 @@
             "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
             "dev": true,
             "requires": {
-                "ajv": "4.11.8",
-                "har-schema": "1.0.5"
+                "ajv": "^4.9.1",
+                "har-schema": "^1.0.5"
             },
             "dependencies": {
                 "ajv": {
@@ -4771,8 +4771,8 @@
                     "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
                     "dev": true,
                     "requires": {
-                        "co": "4.6.0",
-                        "json-stable-stringify": "1.0.1"
+                        "co": "^4.6.0",
+                        "json-stable-stringify": "^1.0.1"
                     }
                 }
             }
@@ -4783,7 +4783,7 @@
             "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
             "dev": true,
             "requires": {
-                "function-bind": "1.1.1"
+                "function-bind": "^1.0.2"
             }
         },
         "has-ansi": {
@@ -4792,7 +4792,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "has-binary": {
@@ -4822,7 +4822,7 @@
             "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "^2.0.1"
             }
         },
         "hash.js": {
@@ -4831,8 +4831,8 @@
             "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.0"
+                "inherits": "^2.0.3",
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "hawk": {
@@ -4841,10 +4841,10 @@
             "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
             "dev": true,
             "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
+                "boom": "2.x.x",
+                "cryptiles": "2.x.x",
+                "hoek": "2.x.x",
+                "sntp": "1.x.x"
             }
         },
         "he": {
@@ -4859,9 +4859,9 @@
             "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
             "dev": true,
             "requires": {
-                "hash.js": "1.1.3",
-                "minimalistic-assert": "1.0.0",
-                "minimalistic-crypto-utils": "1.0.1"
+                "hash.js": "^1.0.3",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.1"
             }
         },
         "hoek": {
@@ -4876,8 +4876,8 @@
             "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
             "dev": true,
             "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.1"
             }
         },
         "homedir-polyfill": {
@@ -4886,7 +4886,7 @@
             "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
             "dev": true,
             "requires": {
-                "parse-passwd": "1.0.0"
+                "parse-passwd": "^1.0.0"
             }
         },
         "hosted-git-info": {
@@ -4901,10 +4901,10 @@
             "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "obuf": "1.1.1",
-                "readable-stream": "2.3.3",
-                "wbuf": "1.7.2"
+                "inherits": "^2.0.1",
+                "obuf": "^1.0.0",
+                "readable-stream": "^2.0.1",
+                "wbuf": "^1.1.0"
             },
             "dependencies": {
                 "isarray": {
@@ -4919,13 +4919,13 @@
                     "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.0.3",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.0.3",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -4934,7 +4934,7 @@
                     "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -4957,14 +4957,14 @@
             "integrity": "sha512-GISXn6oKDo7+gVpKOgZJTbHMCUI2TSGfpg/8jgencWhWJsvEmsvp3M8emX7QocsXsYznWloLib3OeSfeyb/ewg==",
             "dev": true,
             "requires": {
-                "camel-case": "3.0.0",
-                "clean-css": "4.1.9",
-                "commander": "2.12.1",
-                "he": "1.1.1",
-                "ncname": "1.0.0",
-                "param-case": "2.1.1",
-                "relateurl": "0.2.7",
-                "uglify-js": "3.2.0"
+                "camel-case": "3.0.x",
+                "clean-css": "4.1.x",
+                "commander": "2.12.x",
+                "he": "1.1.x",
+                "ncname": "1.0.x",
+                "param-case": "2.1.x",
+                "relateurl": "0.2.x",
+                "uglify-js": "3.2.x"
             }
         },
         "html-webpack-plugin": {
@@ -4973,12 +4973,12 @@
             "integrity": "sha1-LnhjtX5f1I/iYzA+L/yTTDBk0Ak=",
             "dev": true,
             "requires": {
-                "bluebird": "3.5.1",
-                "html-minifier": "3.5.7",
-                "loader-utils": "0.2.17",
-                "lodash": "4.17.4",
-                "pretty-error": "2.1.1",
-                "toposort": "1.0.6"
+                "bluebird": "^3.4.7",
+                "html-minifier": "^3.2.3",
+                "loader-utils": "^0.2.16",
+                "lodash": "^4.17.3",
+                "pretty-error": "^2.0.2",
+                "toposort": "^1.0.0"
             },
             "dependencies": {
                 "lodash": {
@@ -4995,11 +4995,11 @@
             "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.0",
-                "domhandler": "2.3.0",
-                "domutils": "1.5.1",
-                "entities": "1.0.0",
-                "readable-stream": "1.1.14"
+                "domelementtype": "1",
+                "domhandler": "2.3",
+                "domutils": "1.5",
+                "entities": "1.0",
+                "readable-stream": "1.1"
             }
         },
         "http-deceiver": {
@@ -5017,7 +5017,7 @@
                 "depd": "1.1.1",
                 "inherits": "2.0.3",
                 "setprototypeof": "1.0.3",
-                "statuses": "1.4.0"
+                "statuses": ">= 1.3.1 < 2"
             }
         },
         "http-parser-js": {
@@ -5032,8 +5032,8 @@
             "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
             "dev": true,
             "requires": {
-                "eventemitter3": "1.2.0",
-                "requires-port": "1.0.0"
+                "eventemitter3": "1.x.x",
+                "requires-port": "1.x.x"
             }
         },
         "http-proxy-middleware": {
@@ -5042,10 +5042,10 @@
             "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
             "dev": true,
             "requires": {
-                "http-proxy": "1.16.2",
-                "is-glob": "3.1.0",
-                "lodash": "4.17.4",
-                "micromatch": "2.3.11"
+                "http-proxy": "^1.16.2",
+                "is-glob": "^3.1.0",
+                "lodash": "^4.17.2",
+                "micromatch": "^2.3.11"
             },
             "dependencies": {
                 "is-glob": {
@@ -5054,7 +5054,7 @@
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.0"
                     }
                 },
                 "lodash": {
@@ -5071,9 +5071,9 @@
             "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
             "dev": true,
             "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.14.2"
+                "assert-plus": "^0.2.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "https-browserify": {
@@ -5088,8 +5088,8 @@
             "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
             "dev": true,
             "requires": {
-                "agent-base": "4.2.0",
-                "debug": "3.1.0"
+                "agent-base": "^4.1.0",
+                "debug": "^3.1.0"
             },
             "dependencies": {
                 "debug": {
@@ -5176,8 +5176,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -5198,20 +5198,20 @@
             "integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
             "dev": true,
             "requires": {
-                "ansi-escapes": "3.0.0",
-                "chalk": "2.3.0",
-                "cli-cursor": "2.1.0",
-                "cli-width": "2.2.0",
-                "external-editor": "2.0.5",
-                "figures": "2.0.0",
-                "lodash": "4.12.0",
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.0",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^2.0.4",
+                "figures": "^2.0.0",
+                "lodash": "^4.3.0",
                 "mute-stream": "0.0.7",
-                "run-async": "2.3.0",
-                "rx-lite": "4.0.8",
-                "rx-lite-aggregates": "4.0.8",
-                "string-width": "2.1.1",
-                "strip-ansi": "4.0.0",
-                "through": "2.3.8"
+                "run-async": "^2.2.0",
+                "rx-lite": "^4.0.8",
+                "rx-lite-aggregates": "^4.0.8",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^4.0.0",
+                "through": "^2.3.6"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -5226,7 +5226,7 @@
                     "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.0"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -5235,9 +5235,9 @@
                     "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.0",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "4.5.0"
+                        "ansi-styles": "^3.1.0",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -5246,7 +5246,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 },
                 "supports-color": {
@@ -5255,7 +5255,7 @@
                     "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -5277,7 +5277,7 @@
             "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
             "dev": true,
             "requires": {
-                "loose-envify": "1.4.0"
+                "loose-envify": "^1.0.0"
             }
         },
         "invert-kv": {
@@ -5310,7 +5310,7 @@
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
             "dev": true,
             "requires": {
-                "binary-extensions": "1.11.0"
+                "binary-extensions": "^1.0.0"
             }
         },
         "is-buffer": {
@@ -5325,7 +5325,7 @@
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "dev": true,
             "requires": {
-                "builtin-modules": "1.1.1"
+                "builtin-modules": "^1.0.0"
             }
         },
         "is-dotfile": {
@@ -5340,7 +5340,7 @@
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "dev": true,
             "requires": {
-                "is-primitive": "2.0.0"
+                "is-primitive": "^2.0.0"
             }
         },
         "is-extendable": {
@@ -5361,7 +5361,7 @@
             "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
             "dev": true,
             "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
             }
         },
         "is-fullwidth-code-point": {
@@ -5376,7 +5376,7 @@
             "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
             "dev": true,
             "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.1"
             }
         },
         "is-number": {
@@ -5385,7 +5385,7 @@
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "is-path-cwd": {
@@ -5400,7 +5400,7 @@
             "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
             "dev": true,
             "requires": {
-                "is-path-inside": "1.0.0"
+                "is-path-inside": "^1.0.0"
             }
         },
         "is-path-inside": {
@@ -5409,7 +5409,7 @@
             "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
             "dev": true,
             "requires": {
-                "path-is-inside": "1.0.2"
+                "path-is-inside": "^1.0.1"
             }
         },
         "is-plain-obj": {
@@ -5442,7 +5442,7 @@
             "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
             "dev": true,
             "requires": {
-                "tryit": "1.0.3"
+                "tryit": "^1.0.1"
             }
         },
         "is-svg": {
@@ -5451,7 +5451,7 @@
             "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
             "dev": true,
             "requires": {
-                "html-comment-regex": "1.1.1"
+                "html-comment-regex": "^1.1.0"
             }
         },
         "is-typedarray": {
@@ -5484,7 +5484,7 @@
             "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
             "dev": true,
             "requires": {
-                "punycode": "2.1.1"
+                "punycode": "2.x.x"
             },
             "dependencies": {
                 "punycode": {
@@ -5530,9 +5530,9 @@
             "integrity": "sha1-awicChFXax8W3xG4AUbZHU6Lij4=",
             "dev": true,
             "requires": {
-                "exit": "0.1.2",
-                "glob": "7.1.2",
-                "jasmine-core": "2.8.0"
+                "exit": "^0.1.2",
+                "glob": "^7.0.6",
+                "jasmine-core": "~2.8.0"
             },
             "dependencies": {
                 "jasmine-core": {
@@ -5555,8 +5555,8 @@
             "integrity": "sha1-9C1XjplmlhY0MdkRwxZ5cZ+0Ozs=",
             "dev": true,
             "requires": {
-                "mkdirp": "0.5.1",
-                "xmldom": "0.1.27"
+                "mkdirp": "^0.5.1",
+                "xmldom": "^0.1.22"
             }
         },
         "jasminewd2": {
@@ -5571,9 +5571,9 @@
             "integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
             "dev": true,
             "requires": {
-                "hoek": "5.0.4",
-                "isemail": "3.2.0",
-                "topo": "3.0.3"
+                "hoek": "5.x.x",
+                "isemail": "3.x.x",
+                "topo": "3.x.x"
             },
             "dependencies": {
                 "hoek": {
@@ -5607,8 +5607,8 @@
             "integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
             "dev": true,
             "requires": {
-                "argparse": "1.0.9",
-                "esprima": "4.0.0"
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
             }
         },
         "js2xmlparser": {
@@ -5617,7 +5617,7 @@
             "integrity": "sha512-WuNgdZOXVmBk5kUPMcTcVUpbGRzLfNkv7+7APq7WiDihpXVKrgxo6wwRpRl9OQeEBgKCVk9mR7RbzrnNWC8oBw==",
             "dev": true,
             "requires": {
-                "xmlcreate": "2.0.1"
+                "xmlcreate": "^2.0.0"
             }
         },
         "jsbn": {
@@ -5645,14 +5645,14 @@
             "integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
             "dev": true,
             "requires": {
-                "cli": "1.0.1",
-                "console-browserify": "1.1.0",
-                "exit": "0.1.2",
-                "htmlparser2": "3.8.3",
-                "lodash": "3.7.0",
-                "minimatch": "3.0.4",
-                "shelljs": "0.3.0",
-                "strip-json-comments": "1.0.4"
+                "cli": "~1.0.0",
+                "console-browserify": "1.1.x",
+                "exit": "0.1.x",
+                "htmlparser2": "3.8.x",
+                "lodash": "3.7.x",
+                "minimatch": "~3.0.2",
+                "shelljs": "0.3.x",
+                "strip-json-comments": "1.0.x"
             },
             "dependencies": {
                 "lodash": {
@@ -5692,7 +5692,7 @@
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "dev": true,
             "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
             }
         },
         "json-stringify-safe": {
@@ -5745,11 +5745,11 @@
             "integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
             "dev": true,
             "requires": {
-                "core-js": "2.3.0",
-                "es6-promise": "3.0.2",
-                "lie": "3.1.1",
-                "pako": "1.0.6",
-                "readable-stream": "2.0.6"
+                "core-js": "~2.3.0",
+                "es6-promise": "~3.0.2",
+                "lie": "~3.1.0",
+                "pako": "~1.0.2",
+                "readable-stream": "~2.0.6"
             },
             "dependencies": {
                 "core-js": {
@@ -5776,12 +5776,12 @@
                     "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "string_decoder": "0.10.31",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "string_decoder": "~0.10.x",
+                        "util-deprecate": "~1.0.1"
                     }
                 }
             }
@@ -5792,31 +5792,31 @@
             "integrity": "sha1-eM0J4KfTghxiMpH9Hsm61al2PIU=",
             "dev": true,
             "requires": {
-                "bluebird": "3.5.1",
-                "body-parser": "1.18.2",
-                "chokidar": "1.7.0",
-                "colors": "1.1.2",
-                "combine-lists": "1.0.1",
-                "connect": "3.6.5",
-                "core-js": "2.5.1",
-                "di": "0.0.1",
-                "dom-serialize": "2.2.1",
-                "expand-braces": "0.1.2",
-                "glob": "7.1.2",
-                "graceful-fs": "4.1.3",
-                "http-proxy": "1.16.2",
-                "isbinaryfile": "3.0.2",
-                "lodash": "3.10.1",
-                "log4js": "0.6.38",
-                "mime": "1.3.4",
-                "minimatch": "3.0.4",
-                "optimist": "0.6.1",
-                "qjobs": "1.1.5",
-                "rimraf": "2.6.2",
+                "bluebird": "^3.3.0",
+                "body-parser": "^1.12.4",
+                "chokidar": "^1.4.1",
+                "colors": "^1.1.0",
+                "combine-lists": "^1.0.0",
+                "connect": "^3.3.5",
+                "core-js": "^2.2.0",
+                "di": "^0.0.1",
+                "dom-serialize": "^2.2.0",
+                "expand-braces": "^0.1.1",
+                "glob": "^7.0.3",
+                "graceful-fs": "^4.1.2",
+                "http-proxy": "^1.13.0",
+                "isbinaryfile": "^3.0.0",
+                "lodash": "^3.8.0",
+                "log4js": "^0.6.31",
+                "mime": "^1.3.4",
+                "minimatch": "^3.0.0",
+                "optimist": "^0.6.1",
+                "qjobs": "^1.1.4",
+                "rimraf": "^2.3.3",
                 "socket.io": "1.4.7",
-                "source-map": "0.5.7",
+                "source-map": "^0.5.3",
                 "tmp": "0.0.28",
-                "useragent": "2.2.1"
+                "useragent": "^2.1.9"
             },
             "dependencies": {
                 "lodash": {
@@ -5831,7 +5831,7 @@
                     "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
                     "dev": true,
                     "requires": {
-                        "os-tmpdir": "1.0.2"
+                        "os-tmpdir": "~1.0.1"
                     }
                 }
             }
@@ -5842,8 +5842,8 @@
             "integrity": "sha512-uf/ZVpAabDBPvdPdveyk1EPgbnloPvFFGgmRhYLTDH7gEB4nZdSBk8yTU47w1g/drLSx5uMOkjKk7IWKfWg/+w==",
             "dev": true,
             "requires": {
-                "fs-access": "1.0.1",
-                "which": "1.3.0"
+                "fs-access": "^1.0.0",
+                "which": "^1.2.1"
             }
         },
         "karma-jasmine": {
@@ -5858,7 +5858,7 @@
             "integrity": "sha1-T5xAzt+xo5X4rvh2q/lhiZF8Y5Y=",
             "dev": true,
             "requires": {
-                "path-is-absolute": "1.0.1",
+                "path-is-absolute": "^1.0.0",
                 "xmlbuilder": "8.2.2"
             }
         },
@@ -5868,11 +5868,11 @@
             "integrity": "sha512-dcKvtiW00caWrceCKwIvlKwHQu8zI+e3zWZYDLk7kr7nl1lYSp8uP+8fQoBvRCnZiPUGuwU5Psm20NbEIn7KlA==",
             "dev": true,
             "requires": {
-                "async": "0.9.2",
-                "loader-utils": "0.2.17",
-                "lodash": "3.10.1",
-                "source-map": "0.5.7",
-                "webpack-dev-middleware": "1.12.1"
+                "async": "~0.9.0",
+                "loader-utils": "^0.2.5",
+                "lodash": "^3.8.0",
+                "source-map": "^0.5.6",
+                "webpack-dev-middleware": "^1.12.0"
             },
             "dependencies": {
                 "lodash": {
@@ -5889,7 +5889,7 @@
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
             "dev": true,
             "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
             }
         },
         "lazy-cache": {
@@ -5904,7 +5904,7 @@
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
             "dev": true,
             "requires": {
-                "invert-kv": "1.0.0"
+                "invert-kv": "^1.0.0"
             }
         },
         "less": {
@@ -5913,14 +5913,14 @@
             "integrity": "sha512-KPdIJKWcEAb02TuJtaLrhue0krtRLoRoo7x6BNJIBelO00t/CCdJQUnHW5V34OnHMWzIktSalJxRO+FvytQlCQ==",
             "dev": true,
             "requires": {
-                "errno": "0.1.4",
-                "graceful-fs": "4.1.3",
-                "image-size": "0.5.5",
-                "mime": "1.3.4",
-                "mkdirp": "0.5.1",
-                "promise": "7.3.1",
+                "errno": "^0.1.1",
+                "graceful-fs": "^4.1.2",
+                "image-size": "~0.5.0",
+                "mime": "^1.2.11",
+                "mkdirp": "^0.5.0",
+                "promise": "^7.1.1",
                 "request": "2.81.0",
-                "source-map": "0.5.7"
+                "source-map": "^0.5.3"
             }
         },
         "less-loader": {
@@ -5929,9 +5929,9 @@
             "integrity": "sha1-rhVadAbKxqzSk9eFWH/P8PR4xN0=",
             "dev": true,
             "requires": {
-                "clone": "2.1.1",
-                "loader-utils": "1.1.0",
-                "pify": "2.3.0"
+                "clone": "^2.1.1",
+                "loader-utils": "^1.1.0",
+                "pify": "^2.3.0"
             },
             "dependencies": {
                 "clone": {
@@ -5946,9 +5946,9 @@
                     "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
                     "dev": true,
                     "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1"
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0"
                     }
                 }
             }
@@ -5959,8 +5959,8 @@
             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
             "dev": true,
             "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
             }
         },
         "lie": {
@@ -5969,7 +5969,7 @@
             "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
             "dev": true,
             "requires": {
-                "immediate": "3.0.6"
+                "immediate": "~3.0.5"
             }
         },
         "load-json-file": {
@@ -5978,11 +5978,11 @@
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.3",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "strip-bom": "2.0.0"
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
             }
         },
         "loader-runner": {
@@ -5997,10 +5997,10 @@
             "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
             "dev": true,
             "requires": {
-                "big.js": "3.2.0",
-                "emojis-list": "2.1.0",
-                "json5": "0.5.1",
-                "object-assign": "4.1.1"
+                "big.js": "^3.1.3",
+                "emojis-list": "^2.0.0",
+                "json5": "^0.5.0",
+                "object-assign": "^4.0.1"
             }
         },
         "locate-path": {
@@ -6009,8 +6009,8 @@
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
             "dev": true,
             "requires": {
-                "p-locate": "2.0.0",
-                "path-exists": "3.0.0"
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
             },
             "dependencies": {
                 "path-exists": {
@@ -6051,8 +6051,8 @@
             "integrity": "sha1-LElBFmldb7JUgJQ9P8hy5mKlIv0=",
             "dev": true,
             "requires": {
-                "readable-stream": "1.0.34",
-                "semver": "4.3.6"
+                "readable-stream": "~1.0.2",
+                "semver": "~4.3.3"
             },
             "dependencies": {
                 "readable-stream": {
@@ -6061,10 +6061,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "semver": {
@@ -6087,7 +6087,7 @@
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
             "dev": true,
             "requires": {
-                "js-tokens": "3.0.2"
+                "js-tokens": "^3.0.0 || ^4.0.0"
             }
         },
         "lower-case": {
@@ -6114,7 +6114,7 @@
             "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
             "dev": true,
             "requires": {
-                "pify": "3.0.0"
+                "pify": "^3.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -6143,8 +6143,8 @@
             "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
             "dev": true,
             "requires": {
-                "hash-base": "3.0.4",
-                "inherits": "2.0.3"
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1"
             },
             "dependencies": {
                 "hash-base": {
@@ -6153,8 +6153,8 @@
                     "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.3",
-                        "safe-buffer": "5.1.1"
+                        "inherits": "^2.0.1",
+                        "safe-buffer": "^5.0.1"
                     }
                 }
             }
@@ -6171,8 +6171,8 @@
             "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
             "dev": true,
             "requires": {
-                "errno": "0.1.4",
-                "readable-stream": "2.3.3"
+                "errno": "^0.1.3",
+                "readable-stream": "^2.0.1"
             },
             "dependencies": {
                 "isarray": {
@@ -6187,13 +6187,13 @@
                     "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.0.3",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.0.3",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -6202,7 +6202,7 @@
                     "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -6225,19 +6225,19 @@
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
             "dev": true,
             "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.1",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.2.2",
-                "normalize-path": "2.1.1",
-                "object.omit": "2.0.1",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.4"
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
             },
             "dependencies": {
                 "is-extglob": {
@@ -6252,7 +6252,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -6263,8 +6263,8 @@
             "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "brorand": "1.1.0"
+                "bn.js": "^4.0.0",
+                "brorand": "^1.0.1"
             }
         },
         "mime": {
@@ -6285,7 +6285,7 @@
             "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
             "dev": true,
             "requires": {
-                "mime-db": "1.30.0"
+                "mime-db": "~1.30.0"
             }
         },
         "mimic-fn": {
@@ -6312,7 +6312,7 @@
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
-                "brace-expansion": "1.1.8"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -6375,7 +6375,7 @@
             "integrity": "sha1-W1etGLHKCShk72Kwse2BlPODtxw=",
             "dev": true,
             "requires": {
-                "xml-char-classes": "1.0.0"
+                "xml-char-classes": "^1.0.0"
             }
         },
         "negotiator": {
@@ -6399,7 +6399,7 @@
             "resolved": "https://registry.npmjs.org/ngx-order-pipe/-/ngx-order-pipe-2.0.3.tgz",
             "integrity": "sha512-AOZMSk8BukW56J3NSklNZzZGO4Q4bQwMFy0ClDfrf2AcOso8rJApHV4VXqCQJpwn+7EJh3D8uQFLG/9JC7xoqw==",
             "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.9.0"
             }
         },
         "no-case": {
@@ -6408,7 +6408,7 @@
             "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
             "dev": true,
             "requires": {
-                "lower-case": "1.1.4"
+                "lower-case": "^1.1.1"
             }
         },
         "node-dir": {
@@ -6417,7 +6417,7 @@
             "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
             "dev": true,
             "requires": {
-                "minimatch": "3.0.4"
+                "minimatch": "^3.0.2"
             }
         },
         "node-libs-browser": {
@@ -6426,28 +6426,28 @@
             "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
             "dev": true,
             "requires": {
-                "assert": "1.4.1",
-                "browserify-zlib": "0.2.0",
-                "buffer": "4.9.1",
-                "console-browserify": "1.1.0",
-                "constants-browserify": "1.0.0",
-                "crypto-browserify": "3.12.0",
-                "domain-browser": "1.1.7",
-                "events": "1.1.1",
-                "https-browserify": "1.0.0",
-                "os-browserify": "0.3.0",
+                "assert": "^1.1.1",
+                "browserify-zlib": "^0.2.0",
+                "buffer": "^4.3.0",
+                "console-browserify": "^1.1.0",
+                "constants-browserify": "^1.0.0",
+                "crypto-browserify": "^3.11.0",
+                "domain-browser": "^1.1.1",
+                "events": "^1.0.0",
+                "https-browserify": "^1.0.0",
+                "os-browserify": "^0.3.0",
                 "path-browserify": "0.0.0",
-                "process": "0.11.10",
-                "punycode": "1.4.1",
-                "querystring-es3": "0.2.1",
-                "readable-stream": "2.3.3",
-                "stream-browserify": "2.0.1",
-                "stream-http": "2.7.2",
-                "string_decoder": "1.0.3",
-                "timers-browserify": "2.0.4",
+                "process": "^0.11.10",
+                "punycode": "^1.2.4",
+                "querystring-es3": "^0.2.0",
+                "readable-stream": "^2.3.3",
+                "stream-browserify": "^2.0.1",
+                "stream-http": "^2.7.2",
+                "string_decoder": "^1.0.0",
+                "timers-browserify": "^2.0.4",
                 "tty-browserify": "0.0.0",
-                "url": "0.11.0",
-                "util": "0.10.3",
+                "url": "^0.11.0",
+                "util": "^0.10.3",
                 "vm-browserify": "0.0.4"
             },
             "dependencies": {
@@ -6469,13 +6469,13 @@
                     "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.0.3",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.0.3",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -6484,7 +6484,7 @@
                     "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -6495,10 +6495,10 @@
             "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
             "dev": true,
             "requires": {
-                "hosted-git-info": "2.5.0",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.4.1",
-                "validate-npm-package-license": "3.0.1"
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
             }
         },
         "normalize-path": {
@@ -6507,7 +6507,7 @@
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
             }
         },
         "normalize-range": {
@@ -6522,10 +6522,10 @@
             "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
             "dev": true,
             "requires": {
-                "object-assign": "4.1.1",
-                "prepend-http": "1.0.4",
-                "query-string": "4.3.4",
-                "sort-keys": "1.1.2"
+                "object-assign": "^4.0.1",
+                "prepend-http": "^1.0.0",
+                "query-string": "^4.1.0",
+                "sort-keys": "^1.0.0"
             }
         },
         "nth-check": {
@@ -6534,7 +6534,7 @@
             "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
             "dev": true,
             "requires": {
-                "boolbase": "1.0.0"
+                "boolbase": "~1.0.0"
             }
         },
         "null-check": {
@@ -6585,8 +6585,8 @@
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "dev": true,
             "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
             }
         },
         "obuf": {
@@ -6616,7 +6616,7 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "onetime": {
@@ -6625,7 +6625,7 @@
             "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
             "dev": true,
             "requires": {
-                "mimic-fn": "1.1.0"
+                "mimic-fn": "^1.0.0"
             }
         },
         "opn": {
@@ -6634,8 +6634,8 @@
             "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
             "dev": true,
             "requires": {
-                "object-assign": "4.1.1",
-                "pinkie-promise": "2.0.1"
+                "object-assign": "^4.0.1",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "optimist": {
@@ -6644,8 +6644,8 @@
             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
             "dev": true,
             "requires": {
-                "minimist": "0.0.10",
-                "wordwrap": "0.0.3"
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
             },
             "dependencies": {
                 "minimist": {
@@ -6668,12 +6668,12 @@
             "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
             "dev": true,
             "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.4",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "wordwrap": "~1.0.0"
             }
         },
         "options": {
@@ -6688,7 +6688,7 @@
             "integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
             "dev": true,
             "requires": {
-                "url-parse": "1.0.5"
+                "url-parse": "1.0.x"
             },
             "dependencies": {
                 "url-parse": {
@@ -6697,8 +6697,8 @@
                     "integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
                     "dev": true,
                     "requires": {
-                        "querystringify": "0.0.4",
-                        "requires-port": "1.0.0"
+                        "querystringify": "0.0.x",
+                        "requires-port": "1.0.x"
                     }
                 }
             }
@@ -6721,7 +6721,7 @@
             "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
             "dev": true,
             "requires": {
-                "lcid": "1.0.0"
+                "lcid": "^1.0.0"
             }
         },
         "os-tmpdir": {
@@ -6736,7 +6736,7 @@
             "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
             "dev": true,
             "requires": {
-                "p-try": "1.0.0"
+                "p-try": "^1.0.0"
             }
         },
         "p-locate": {
@@ -6745,7 +6745,7 @@
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
             "dev": true,
             "requires": {
-                "p-limit": "1.3.0"
+                "p-limit": "^1.1.0"
             }
         },
         "p-map": {
@@ -6772,7 +6772,7 @@
             "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
             "dev": true,
             "requires": {
-                "no-case": "2.3.2"
+                "no-case": "^2.2.0"
             }
         },
         "parse-asn1": {
@@ -6781,11 +6781,11 @@
             "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
             "dev": true,
             "requires": {
-                "asn1.js": "4.9.2",
-                "browserify-aes": "1.1.1",
-                "create-hash": "1.1.3",
-                "evp_bytestokey": "1.0.3",
-                "pbkdf2": "3.0.14"
+                "asn1.js": "^4.0.0",
+                "browserify-aes": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.0",
+                "pbkdf2": "^3.0.3"
             }
         },
         "parse-glob": {
@@ -6794,10 +6794,10 @@
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
             "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -6812,7 +6812,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -6823,7 +6823,7 @@
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
             "dev": true,
             "requires": {
-                "error-ex": "1.3.1"
+                "error-ex": "^1.2.0"
             }
         },
         "parse-passwd": {
@@ -6838,7 +6838,7 @@
             "integrity": "sha1-mxDGwNglq1ieaFFTgm3go7oni8w=",
             "dev": true,
             "requires": {
-                "better-assert": "1.0.2"
+                "better-assert": "~1.0.0"
             }
         },
         "parseqs": {
@@ -6847,7 +6847,7 @@
             "integrity": "sha1-nf5wss3aw4i95PNbHyQPpYrb5sc=",
             "dev": true,
             "requires": {
-                "better-assert": "1.0.2"
+                "better-assert": "~1.0.0"
             }
         },
         "parseuri": {
@@ -6856,7 +6856,7 @@
             "integrity": "sha1-gGWCo5iH4eoY3V4v4OAZAiaOk1A=",
             "dev": true,
             "requires": {
-                "better-assert": "1.0.2"
+                "better-assert": "~1.0.0"
             }
         },
         "parseurl": {
@@ -6877,7 +6877,7 @@
             "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
             "dev": true,
             "requires": {
-                "pinkie-promise": "2.0.1"
+                "pinkie-promise": "^2.0.0"
             }
         },
         "path-is-absolute": {
@@ -6910,9 +6910,9 @@
             "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.3",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "pbkdf2": {
@@ -6921,11 +6921,11 @@
             "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
             "dev": true,
             "requires": {
-                "create-hash": "1.1.3",
-                "create-hmac": "1.1.6",
-                "ripemd160": "2.0.1",
-                "safe-buffer": "5.1.1",
-                "sha.js": "2.4.9"
+                "create-hash": "^1.1.2",
+                "create-hmac": "^1.1.4",
+                "ripemd160": "^2.0.1",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
             }
         },
         "performance-now": {
@@ -6952,7 +6952,7 @@
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "dev": true,
             "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
             }
         },
         "pkg-dir": {
@@ -6961,7 +6961,7 @@
             "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
             "dev": true,
             "requires": {
-                "find-up": "2.1.0"
+                "find-up": "^2.1.0"
             },
             "dependencies": {
                 "find-up": {
@@ -6970,7 +6970,7 @@
                     "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
                     "dev": true,
                     "requires": {
-                        "locate-path": "2.0.0"
+                        "locate-path": "^2.0.0"
                     }
                 }
             }
@@ -6987,9 +6987,9 @@
             "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
             "dev": true,
             "requires": {
-                "async": "1.5.2",
-                "debug": "2.2.0",
-                "mkdirp": "0.5.1"
+                "async": "^1.5.2",
+                "debug": "^2.2.0",
+                "mkdirp": "0.5.x"
             },
             "dependencies": {
                 "async": {
@@ -7006,10 +7006,10 @@
             "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "js-base64": "2.3.2",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3"
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
             },
             "dependencies": {
                 "has-flag": {
@@ -7024,7 +7024,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -7035,9 +7035,9 @@
             "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "postcss-message-helpers": "2.0.0",
-                "reduce-css-calc": "1.3.0"
+                "postcss": "^5.0.2",
+                "postcss-message-helpers": "^2.0.0",
+                "reduce-css-calc": "^1.2.6"
             }
         },
         "postcss-colormin": {
@@ -7046,9 +7046,9 @@
             "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
             "dev": true,
             "requires": {
-                "colormin": "1.1.2",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "colormin": "^1.0.5",
+                "postcss": "^5.0.13",
+                "postcss-value-parser": "^3.2.3"
             }
         },
         "postcss-convert-values": {
@@ -7057,8 +7057,8 @@
             "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "postcss": "^5.0.11",
+                "postcss-value-parser": "^3.1.2"
             }
         },
         "postcss-discard-comments": {
@@ -7067,7 +7067,7 @@
             "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.14"
             }
         },
         "postcss-discard-duplicates": {
@@ -7076,7 +7076,7 @@
             "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.4"
             }
         },
         "postcss-discard-empty": {
@@ -7085,7 +7085,7 @@
             "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.14"
             }
         },
         "postcss-discard-overridden": {
@@ -7094,7 +7094,7 @@
             "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.16"
             }
         },
         "postcss-discard-unused": {
@@ -7103,8 +7103,8 @@
             "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "uniqs": "2.0.0"
+                "postcss": "^5.0.14",
+                "uniqs": "^2.0.0"
             }
         },
         "postcss-filter-plugins": {
@@ -7113,8 +7113,8 @@
             "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "uniqid": "4.1.1"
+                "postcss": "^5.0.4",
+                "uniqid": "^4.0.0"
             }
         },
         "postcss-merge-idents": {
@@ -7123,9 +7123,9 @@
             "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
             "dev": true,
             "requires": {
-                "has": "1.0.1",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "has": "^1.0.1",
+                "postcss": "^5.0.10",
+                "postcss-value-parser": "^3.1.1"
             }
         },
         "postcss-merge-longhand": {
@@ -7134,7 +7134,7 @@
             "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.4"
             }
         },
         "postcss-merge-rules": {
@@ -7143,11 +7143,11 @@
             "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
             "dev": true,
             "requires": {
-                "browserslist": "1.7.7",
-                "caniuse-api": "1.6.1",
-                "postcss": "5.2.18",
-                "postcss-selector-parser": "2.2.3",
-                "vendors": "1.0.1"
+                "browserslist": "^1.5.2",
+                "caniuse-api": "^1.5.2",
+                "postcss": "^5.0.4",
+                "postcss-selector-parser": "^2.2.2",
+                "vendors": "^1.0.0"
             }
         },
         "postcss-message-helpers": {
@@ -7162,9 +7162,9 @@
             "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
             "dev": true,
             "requires": {
-                "object-assign": "4.1.1",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "object-assign": "^4.0.1",
+                "postcss": "^5.0.4",
+                "postcss-value-parser": "^3.0.2"
             }
         },
         "postcss-minify-gradients": {
@@ -7173,8 +7173,8 @@
             "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "postcss": "^5.0.12",
+                "postcss-value-parser": "^3.3.0"
             }
         },
         "postcss-minify-params": {
@@ -7183,10 +7183,10 @@
             "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
             "dev": true,
             "requires": {
-                "alphanum-sort": "1.0.2",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0",
-                "uniqs": "2.0.0"
+                "alphanum-sort": "^1.0.1",
+                "postcss": "^5.0.2",
+                "postcss-value-parser": "^3.0.2",
+                "uniqs": "^2.0.0"
             }
         },
         "postcss-minify-selectors": {
@@ -7195,10 +7195,10 @@
             "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
             "dev": true,
             "requires": {
-                "alphanum-sort": "1.0.2",
-                "has": "1.0.1",
-                "postcss": "5.2.18",
-                "postcss-selector-parser": "2.2.3"
+                "alphanum-sort": "^1.0.2",
+                "has": "^1.0.1",
+                "postcss": "^5.0.14",
+                "postcss-selector-parser": "^2.0.0"
             }
         },
         "postcss-modules-extract-imports": {
@@ -7207,7 +7207,7 @@
             "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
             "dev": true,
             "requires": {
-                "postcss": "6.0.14"
+                "postcss": "^6.0.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -7216,7 +7216,7 @@
                     "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.0"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -7225,9 +7225,9 @@
                     "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.0",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "4.5.0"
+                        "ansi-styles": "^3.1.0",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^4.0.0"
                     }
                 },
                 "postcss": {
@@ -7236,9 +7236,9 @@
                     "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.3.0",
-                        "source-map": "0.6.1",
-                        "supports-color": "4.5.0"
+                        "chalk": "^2.3.0",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^4.4.0"
                     }
                 },
                 "source-map": {
@@ -7253,7 +7253,7 @@
                     "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -7264,8 +7264,8 @@
             "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
             "dev": true,
             "requires": {
-                "css-selector-tokenizer": "0.7.0",
-                "postcss": "6.0.14"
+                "css-selector-tokenizer": "^0.7.0",
+                "postcss": "^6.0.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -7274,7 +7274,7 @@
                     "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.0"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -7283,9 +7283,9 @@
                     "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.0",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "4.5.0"
+                        "ansi-styles": "^3.1.0",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^4.0.0"
                     }
                 },
                 "postcss": {
@@ -7294,9 +7294,9 @@
                     "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.3.0",
-                        "source-map": "0.6.1",
-                        "supports-color": "4.5.0"
+                        "chalk": "^2.3.0",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^4.4.0"
                     }
                 },
                 "source-map": {
@@ -7311,7 +7311,7 @@
                     "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -7322,8 +7322,8 @@
             "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
             "dev": true,
             "requires": {
-                "css-selector-tokenizer": "0.7.0",
-                "postcss": "6.0.14"
+                "css-selector-tokenizer": "^0.7.0",
+                "postcss": "^6.0.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -7332,7 +7332,7 @@
                     "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.0"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -7341,9 +7341,9 @@
                     "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.0",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "4.5.0"
+                        "ansi-styles": "^3.1.0",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^4.0.0"
                     }
                 },
                 "postcss": {
@@ -7352,9 +7352,9 @@
                     "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.3.0",
-                        "source-map": "0.6.1",
-                        "supports-color": "4.5.0"
+                        "chalk": "^2.3.0",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^4.4.0"
                     }
                 },
                 "source-map": {
@@ -7369,7 +7369,7 @@
                     "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -7380,8 +7380,8 @@
             "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
             "dev": true,
             "requires": {
-                "icss-replace-symbols": "1.1.0",
-                "postcss": "6.0.14"
+                "icss-replace-symbols": "^1.1.0",
+                "postcss": "^6.0.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -7390,7 +7390,7 @@
                     "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.0"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -7399,9 +7399,9 @@
                     "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.0",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "4.5.0"
+                        "ansi-styles": "^3.1.0",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^4.0.0"
                     }
                 },
                 "postcss": {
@@ -7410,9 +7410,9 @@
                     "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.3.0",
-                        "source-map": "0.6.1",
-                        "supports-color": "4.5.0"
+                        "chalk": "^2.3.0",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^4.4.0"
                     }
                 },
                 "source-map": {
@@ -7427,7 +7427,7 @@
                     "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -7438,7 +7438,7 @@
             "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.5"
             }
         },
         "postcss-normalize-url": {
@@ -7447,10 +7447,10 @@
             "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
             "dev": true,
             "requires": {
-                "is-absolute-url": "2.1.0",
-                "normalize-url": "1.9.1",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "is-absolute-url": "^2.0.0",
+                "normalize-url": "^1.4.0",
+                "postcss": "^5.0.14",
+                "postcss-value-parser": "^3.2.3"
             }
         },
         "postcss-ordered-values": {
@@ -7459,8 +7459,8 @@
             "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "postcss": "^5.0.4",
+                "postcss-value-parser": "^3.0.1"
             }
         },
         "postcss-reduce-idents": {
@@ -7469,8 +7469,8 @@
             "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "postcss": "^5.0.4",
+                "postcss-value-parser": "^3.0.2"
             }
         },
         "postcss-reduce-initial": {
@@ -7479,7 +7479,7 @@
             "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.4"
             }
         },
         "postcss-reduce-transforms": {
@@ -7488,9 +7488,9 @@
             "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
             "dev": true,
             "requires": {
-                "has": "1.0.1",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "has": "^1.0.1",
+                "postcss": "^5.0.8",
+                "postcss-value-parser": "^3.0.1"
             }
         },
         "postcss-selector-parser": {
@@ -7499,9 +7499,9 @@
             "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
             "dev": true,
             "requires": {
-                "flatten": "1.0.2",
-                "indexes-of": "1.0.1",
-                "uniq": "1.0.1"
+                "flatten": "^1.0.2",
+                "indexes-of": "^1.0.1",
+                "uniq": "^1.0.1"
             }
         },
         "postcss-svgo": {
@@ -7510,10 +7510,10 @@
             "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
             "dev": true,
             "requires": {
-                "is-svg": "2.1.0",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0",
-                "svgo": "0.7.2"
+                "is-svg": "^2.0.0",
+                "postcss": "^5.0.14",
+                "postcss-value-parser": "^3.2.3",
+                "svgo": "^0.7.0"
             }
         },
         "postcss-unique-selectors": {
@@ -7522,9 +7522,9 @@
             "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
             "dev": true,
             "requires": {
-                "alphanum-sort": "1.0.2",
-                "postcss": "5.2.18",
-                "uniqs": "2.0.0"
+                "alphanum-sort": "^1.0.1",
+                "postcss": "^5.0.4",
+                "uniqs": "^2.0.0"
             }
         },
         "postcss-value-parser": {
@@ -7539,9 +7539,9 @@
             "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
             "dev": true,
             "requires": {
-                "has": "1.0.1",
-                "postcss": "5.2.18",
-                "uniqs": "2.0.0"
+                "has": "^1.0.1",
+                "postcss": "^5.0.4",
+                "uniqs": "^2.0.0"
             }
         },
         "prelude-ls": {
@@ -7568,8 +7568,8 @@
             "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
             "dev": true,
             "requires": {
-                "renderkid": "2.0.1",
-                "utila": "0.4.0"
+                "renderkid": "^2.0.1",
+                "utila": "~0.4"
             }
         },
         "private": {
@@ -7597,7 +7597,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "asap": "2.0.6"
+                "asap": "~2.0.3"
             }
         },
         "protractor": {
@@ -7606,21 +7606,21 @@
             "integrity": "sha512-pw4uwwiy5lHZjIguxNpkEwJJa7hVz+bJsvaTI+IbXlfn2qXwzbF8eghW/RmrZwE2sGx82I8etb8lVjQ+JrjejA==",
             "dev": true,
             "requires": {
-                "@types/node": "6.0.113",
-                "@types/q": "0.0.32",
-                "@types/selenium-webdriver": "2.53.43",
-                "blocking-proxy": "1.0.1",
-                "chalk": "1.1.3",
-                "glob": "7.1.2",
+                "@types/node": "^6.0.46",
+                "@types/q": "^0.0.32",
+                "@types/selenium-webdriver": "~2.53.39",
+                "blocking-proxy": "^1.0.0",
+                "chalk": "^1.1.3",
+                "glob": "^7.0.3",
                 "jasmine": "2.8.0",
-                "jasminewd2": "2.2.0",
-                "optimist": "0.6.1",
+                "jasminewd2": "^2.1.0",
+                "optimist": "~0.6.0",
                 "q": "1.4.1",
-                "saucelabs": "1.5.0",
+                "saucelabs": "^1.5.0",
                 "selenium-webdriver": "3.6.0",
-                "source-map-support": "0.4.18",
-                "webdriver-js-extender": "1.0.0",
-                "webdriver-manager": "12.0.6"
+                "source-map-support": "~0.4.0",
+                "webdriver-js-extender": "^1.0.0",
+                "webdriver-manager": "^12.0.6"
             },
             "dependencies": {
                 "adm-zip": {
@@ -7641,17 +7641,17 @@
                     "integrity": "sha1-PfGkgZdwELTL+MnYXHpXeCjA5ws=",
                     "dev": true,
                     "requires": {
-                        "adm-zip": "0.4.11",
-                        "chalk": "1.1.3",
-                        "del": "2.2.2",
-                        "glob": "7.1.2",
-                        "ini": "1.3.5",
-                        "minimist": "1.2.0",
-                        "q": "1.4.1",
-                        "request": "2.81.0",
-                        "rimraf": "2.6.2",
-                        "semver": "5.4.1",
-                        "xml2js": "0.4.19"
+                        "adm-zip": "^0.4.7",
+                        "chalk": "^1.1.1",
+                        "del": "^2.2.0",
+                        "glob": "^7.0.3",
+                        "ini": "^1.3.4",
+                        "minimist": "^1.2.0",
+                        "q": "^1.4.1",
+                        "request": "^2.78.0",
+                        "rimraf": "^2.5.2",
+                        "semver": "^5.3.0",
+                        "xml2js": "^0.4.17"
                     }
                 }
             }
@@ -7662,7 +7662,7 @@
             "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
             "dev": true,
             "requires": {
-                "forwarded": "0.1.2",
+                "forwarded": "~0.1.2",
                 "ipaddr.js": "1.5.2"
             }
         },
@@ -7690,11 +7690,11 @@
             "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "browserify-rsa": "4.0.1",
-                "create-hash": "1.1.3",
-                "parse-asn1": "5.1.0",
-                "randombytes": "2.0.5"
+                "bn.js": "^4.1.0",
+                "browserify-rsa": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "parse-asn1": "^5.0.0",
+                "randombytes": "^2.0.1"
             }
         },
         "punycode": {
@@ -7727,8 +7727,8 @@
             "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
             "dev": true,
             "requires": {
-                "object-assign": "4.1.1",
-                "strict-uri-encode": "1.1.0"
+                "object-assign": "^4.1.0",
+                "strict-uri-encode": "^1.0.0"
             }
         },
         "querystring": {
@@ -7755,8 +7755,8 @@
             "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -7765,7 +7765,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -7774,7 +7774,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -7785,7 +7785,7 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -7796,7 +7796,7 @@
             "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "^5.1.0"
             }
         },
         "randomfill": {
@@ -7805,8 +7805,8 @@
             "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
             "dev": true,
             "requires": {
-                "randombytes": "2.0.5",
-                "safe-buffer": "5.1.1"
+                "randombytes": "^2.0.5",
+                "safe-buffer": "^5.1.0"
             }
         },
         "range-parser": {
@@ -7839,9 +7839,9 @@
             "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
             "dev": true,
             "requires": {
-                "load-json-file": "1.1.0",
-                "normalize-package-data": "2.4.0",
-                "path-type": "1.1.0"
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
             }
         },
         "read-pkg-up": {
@@ -7850,8 +7850,8 @@
             "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
             "dev": true,
             "requires": {
-                "find-up": "1.1.2",
-                "read-pkg": "1.1.0"
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
             }
         },
         "readable-stream": {
@@ -7860,10 +7860,10 @@
             "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
             "dev": true,
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
                 "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
+                "string_decoder": "~0.10.x"
             }
         },
         "readdirp": {
@@ -7872,10 +7872,10 @@
             "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.3",
-                "minimatch": "3.0.4",
-                "readable-stream": "2.3.3",
-                "set-immediate-shim": "1.0.1"
+                "graceful-fs": "^4.1.2",
+                "minimatch": "^3.0.2",
+                "readable-stream": "^2.0.2",
+                "set-immediate-shim": "^1.0.1"
             },
             "dependencies": {
                 "isarray": {
@@ -7890,13 +7890,13 @@
                     "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.0.3",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.0.3",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -7905,7 +7905,7 @@
                     "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -7916,9 +7916,9 @@
             "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
             "dev": true,
             "requires": {
-                "balanced-match": "0.4.2",
-                "math-expression-evaluator": "1.2.17",
-                "reduce-function-call": "1.0.2"
+                "balanced-match": "^0.4.2",
+                "math-expression-evaluator": "^1.2.14",
+                "reduce-function-call": "^1.0.1"
             },
             "dependencies": {
                 "balanced-match": {
@@ -7935,7 +7935,7 @@
             "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
             "dev": true,
             "requires": {
-                "balanced-match": "0.4.2"
+                "balanced-match": "^0.4.2"
             },
             "dependencies": {
                 "balanced-match": {
@@ -7968,9 +7968,9 @@
             "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "private": "0.1.8"
+                "babel-runtime": "^6.18.0",
+                "babel-types": "^6.19.0",
+                "private": "^0.1.6"
             }
         },
         "regex-cache": {
@@ -7979,7 +7979,7 @@
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "dev": true,
             "requires": {
-                "is-equal-shallow": "0.1.3"
+                "is-equal-shallow": "^0.1.3"
             }
         },
         "regexpu-core": {
@@ -7988,9 +7988,9 @@
             "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
             "dev": true,
             "requires": {
-                "regenerate": "1.3.3",
-                "regjsgen": "0.2.0",
-                "regjsparser": "0.1.5"
+                "regenerate": "^1.2.1",
+                "regjsgen": "^0.2.0",
+                "regjsparser": "^0.1.4"
             }
         },
         "regjsgen": {
@@ -8005,7 +8005,7 @@
             "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
             "dev": true,
             "requires": {
-                "jsesc": "0.5.0"
+                "jsesc": "~0.5.0"
             }
         },
         "relateurl": {
@@ -8026,11 +8026,11 @@
             "integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
             "dev": true,
             "requires": {
-                "css-select": "1.2.0",
-                "dom-converter": "0.1.4",
-                "htmlparser2": "3.3.0",
-                "strip-ansi": "3.0.1",
-                "utila": "0.3.3"
+                "css-select": "^1.1.0",
+                "dom-converter": "~0.1",
+                "htmlparser2": "~3.3.0",
+                "strip-ansi": "^3.0.0",
+                "utila": "~0.3"
             },
             "dependencies": {
                 "domhandler": {
@@ -8039,7 +8039,7 @@
                     "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
                     "dev": true,
                     "requires": {
-                        "domelementtype": "1.3.0"
+                        "domelementtype": "1"
                     }
                 },
                 "domutils": {
@@ -8048,7 +8048,7 @@
                     "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
                     "dev": true,
                     "requires": {
-                        "domelementtype": "1.3.0"
+                        "domelementtype": "1"
                     }
                 },
                 "htmlparser2": {
@@ -8057,10 +8057,10 @@
                     "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
                     "dev": true,
                     "requires": {
-                        "domelementtype": "1.3.0",
-                        "domhandler": "2.1.0",
-                        "domutils": "1.1.6",
-                        "readable-stream": "1.0.34"
+                        "domelementtype": "1",
+                        "domhandler": "2.1",
+                        "domutils": "1.1",
+                        "readable-stream": "1.0"
                     }
                 },
                 "readable-stream": {
@@ -8069,10 +8069,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "utila": {
@@ -8101,7 +8101,7 @@
             "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
             "dev": true,
             "requires": {
-                "is-finite": "1.0.2"
+                "is-finite": "^1.0.0"
             }
         },
         "request": {
@@ -8110,28 +8110,28 @@
             "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
             "dev": true,
             "requires": {
-                "aws-sign2": "0.6.0",
-                "aws4": "1.7.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.6",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.1.4",
-                "har-validator": "4.2.1",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
-                "oauth-sign": "0.8.2",
-                "performance-now": "0.2.0",
-                "qs": "6.4.0",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.6",
-                "tough-cookie": "2.3.4",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.2.1"
+                "aws-sign2": "~0.6.0",
+                "aws4": "^1.2.1",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.0",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.1.1",
+                "har-validator": "~4.2.1",
+                "hawk": "~3.1.3",
+                "http-signature": "~1.1.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.7",
+                "oauth-sign": "~0.8.1",
+                "performance-now": "^0.2.0",
+                "qs": "~6.4.0",
+                "safe-buffer": "^5.0.1",
+                "stringstream": "~0.0.4",
+                "tough-cookie": "~2.3.0",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.0.0"
             },
             "dependencies": {
                 "qs": {
@@ -8160,8 +8160,8 @@
             "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
             "dev": true,
             "requires": {
-                "caller-path": "0.1.0",
-                "resolve-from": "1.0.1"
+                "caller-path": "^0.1.0",
+                "resolve-from": "^1.0.0"
             }
         },
         "requirejs": {
@@ -8182,7 +8182,7 @@
             "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
             "dev": true,
             "requires": {
-                "path-parse": "1.0.6"
+                "path-parse": "^1.0.6"
             }
         },
         "resolve-from": {
@@ -8197,8 +8197,8 @@
             "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
             "dev": true,
             "requires": {
-                "onetime": "2.0.1",
-                "signal-exit": "3.0.2"
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
             }
         },
         "right-align": {
@@ -8207,7 +8207,7 @@
             "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
             "dev": true,
             "requires": {
-                "align-text": "0.1.4"
+                "align-text": "^0.1.1"
             }
         },
         "rimraf": {
@@ -8216,7 +8216,7 @@
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
             }
         },
         "ripemd160": {
@@ -8225,8 +8225,8 @@
             "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
             "dev": true,
             "requires": {
-                "hash-base": "2.0.2",
-                "inherits": "2.0.3"
+                "hash-base": "^2.0.0",
+                "inherits": "^2.0.1"
             }
         },
         "run-async": {
@@ -8235,7 +8235,7 @@
             "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
             "dev": true,
             "requires": {
-                "is-promise": "2.1.0"
+                "is-promise": "^2.1.0"
             }
         },
         "rx": {
@@ -8256,7 +8256,7 @@
             "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
             "dev": true,
             "requires": {
-                "rx-lite": "4.0.8"
+                "rx-lite": "*"
             }
         },
         "rxjs": {
@@ -8264,7 +8264,7 @@
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.1.tgz",
             "integrity": "sha512-y0j31WJc83wPu31vS1VlAFW5JGrnGC+j+TtGAa1fRQphy48+fDYiDmX8tjGloToEsMkxnouOg/1IzXGKkJnZMg==",
             "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.9.0"
             },
             "dependencies": {
                 "tslib": {
@@ -8292,7 +8292,7 @@
             "integrity": "sha512-jlX3FGdWvYf4Q3LFfFWS1QvPg3IGCGWxIc8QBFdPTbpTJnt/v17FHXYVAn7C8sHf1yUXo2c7yIM0isDryfYtHQ==",
             "dev": true,
             "requires": {
-                "https-proxy-agent": "2.2.1"
+                "https-proxy-agent": "^2.2.1"
             }
         },
         "sax": {
@@ -8324,12 +8324,12 @@
                     "integrity": "sha512-/BnSJ+SuZyLu7xMn48kZY0nMXDi+5KNmR4g8n21Wivsl8+B9njV6/5kcTNE9juSprp0zRWBU28JuHUq0FqK1Nw==",
                     "dev": true,
                     "requires": {
-                        "globby": "6.1.0",
-                        "is-path-cwd": "2.1.0",
-                        "is-path-in-cwd": "2.1.0",
-                        "p-map": "2.1.0",
-                        "pify": "4.0.1",
-                        "rimraf": "2.6.2"
+                        "globby": "^6.1.0",
+                        "is-path-cwd": "^2.0.0",
+                        "is-path-in-cwd": "^2.0.0",
+                        "p-map": "^2.0.0",
+                        "pify": "^4.0.1",
+                        "rimraf": "^2.6.2"
                     }
                 },
                 "glob": {
@@ -8338,12 +8338,12 @@
                     "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "globby": {
@@ -8352,11 +8352,11 @@
                     "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
                     "dev": true,
                     "requires": {
-                        "array-union": "1.0.2",
-                        "glob": "7.1.4",
-                        "object-assign": "4.1.1",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "array-union": "^1.0.1",
+                        "glob": "^7.0.3",
+                        "object-assign": "^4.0.1",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     },
                     "dependencies": {
                         "pify": {
@@ -8379,7 +8379,7 @@
                     "integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
                     "dev": true,
                     "requires": {
-                        "is-path-inside": "2.1.0"
+                        "is-path-inside": "^2.1.0"
                     }
                 },
                 "is-path-inside": {
@@ -8388,7 +8388,7 @@
                     "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
                     "dev": true,
                     "requires": {
-                        "path-is-inside": "1.0.2"
+                        "path-is-inside": "^1.0.2"
                     }
                 },
                 "lodash": {
@@ -8417,7 +8417,7 @@
             "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
             "dev": true,
             "requires": {
-                "ajv": "5.5.0"
+                "ajv": "^5.0.0"
             },
             "dependencies": {
                 "ajv": {
@@ -8426,10 +8426,10 @@
                     "integrity": "sha1-6yhAdG6dxIvV4GOjbj/UAMXqtak=",
                     "dev": true,
                     "requires": {
-                        "co": "4.6.0",
-                        "fast-deep-equal": "1.0.0",
-                        "fast-json-stable-stringify": "2.0.0",
-                        "json-schema-traverse": "0.3.1"
+                        "co": "^4.6.0",
+                        "fast-deep-equal": "^1.0.0",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.3.0"
                     }
                 }
             }
@@ -8446,10 +8446,10 @@
             "integrity": "sha512-WH7Aldse+2P5bbFBO4Gle/nuQOdVwpHMTL6raL3uuBj/vPG07k6uzt3aiahu352ONBr5xXh0hDlM3LhtXPOC4Q==",
             "dev": true,
             "requires": {
-                "jszip": "3.1.5",
-                "rimraf": "2.6.2",
+                "jszip": "^3.1.3",
+                "rimraf": "^2.5.4",
                 "tmp": "0.0.30",
-                "xml2js": "0.4.19"
+                "xml2js": "^0.4.17"
             }
         },
         "semver": {
@@ -8465,18 +8465,18 @@
             "dev": true,
             "requires": {
                 "debug": "2.6.9",
-                "depd": "1.1.1",
-                "destroy": "1.0.4",
-                "encodeurl": "1.0.1",
-                "escape-html": "1.0.3",
-                "etag": "1.8.1",
+                "depd": "~1.1.1",
+                "destroy": "~1.0.4",
+                "encodeurl": "~1.0.1",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
                 "fresh": "0.5.2",
-                "http-errors": "1.6.2",
+                "http-errors": "~1.6.2",
                 "mime": "1.4.1",
                 "ms": "2.0.0",
-                "on-finished": "2.3.0",
-                "range-parser": "1.2.0",
-                "statuses": "1.3.1"
+                "on-finished": "~2.3.0",
+                "range-parser": "~1.2.0",
+                "statuses": "~1.3.1"
             },
             "dependencies": {
                 "debug": {
@@ -8514,13 +8514,13 @@
             "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
             "dev": true,
             "requires": {
-                "accepts": "1.3.4",
+                "accepts": "~1.3.4",
                 "batch": "0.6.1",
                 "debug": "2.6.9",
-                "escape-html": "1.0.3",
-                "http-errors": "1.6.2",
-                "mime-types": "2.1.17",
-                "parseurl": "1.3.2"
+                "escape-html": "~1.0.3",
+                "http-errors": "~1.6.2",
+                "mime-types": "~2.1.17",
+                "parseurl": "~1.3.2"
             },
             "dependencies": {
                 "accepts": {
@@ -8529,7 +8529,7 @@
                     "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
                     "dev": true,
                     "requires": {
-                        "mime-types": "2.1.17",
+                        "mime-types": "~2.1.16",
                         "negotiator": "0.6.1"
                     }
                 },
@@ -8562,9 +8562,9 @@
             "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
             "dev": true,
             "requires": {
-                "encodeurl": "1.0.1",
-                "escape-html": "1.0.3",
-                "parseurl": "1.3.2",
+                "encodeurl": "~1.0.1",
+                "escape-html": "~1.0.3",
+                "parseurl": "~1.3.2",
                 "send": "0.16.1"
             }
         },
@@ -8598,8 +8598,8 @@
             "integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.1"
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "shebang-command": {
@@ -8608,7 +8608,7 @@
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "dev": true,
             "requires": {
-                "shebang-regex": "1.0.0"
+                "shebang-regex": "^1.0.0"
             }
         },
         "shebang-regex": {
@@ -8647,7 +8647,7 @@
             "integrity": "sha1-BE8aSdiEL/MHqta1Be0Xi9lQE00=",
             "dev": true,
             "requires": {
-                "is-fullwidth-code-point": "2.0.0"
+                "is-fullwidth-code-point": "^2.0.0"
             }
         },
         "sntp": {
@@ -8656,7 +8656,7 @@
             "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
             "dev": true,
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
             }
         },
         "socket.io": {
@@ -8760,8 +8760,8 @@
             "integrity": "sha1-2bKJMWyn33dZXvKZ4HXw+TfrQgc=",
             "dev": true,
             "requires": {
-                "faye-websocket": "0.10.0",
-                "uuid": "2.0.3"
+                "faye-websocket": "^0.10.0",
+                "uuid": "^2.0.2"
             },
             "dependencies": {
                 "uuid": {
@@ -8778,12 +8778,12 @@
             "integrity": "sha1-8CEqhVDkyUaMjM6u79LjSTwDOtU=",
             "dev": true,
             "requires": {
-                "debug": "2.2.0",
+                "debug": "^2.2.0",
                 "eventsource": "0.1.6",
-                "faye-websocket": "0.11.1",
-                "inherits": "2.0.3",
-                "json3": "3.3.2",
-                "url-parse": "1.2.0"
+                "faye-websocket": "~0.11.0",
+                "inherits": "^2.0.1",
+                "json3": "^3.3.2",
+                "url-parse": "^1.1.1"
             },
             "dependencies": {
                 "faye-websocket": {
@@ -8792,7 +8792,7 @@
                     "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
                     "dev": true,
                     "requires": {
-                        "websocket-driver": "0.7.0"
+                        "websocket-driver": ">=0.5.1"
                     }
                 },
                 "json3": {
@@ -8809,7 +8809,7 @@
             "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
             "dev": true,
             "requires": {
-                "is-plain-obj": "1.1.0"
+                "is-plain-obj": "^1.0.0"
             }
         },
         "source-list-map": {
@@ -8830,7 +8830,7 @@
             "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
             "dev": true,
             "requires": {
-                "source-map": "0.5.7"
+                "source-map": "^0.5.6"
             }
         },
         "spdx-correct": {
@@ -8839,7 +8839,7 @@
             "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
             "dev": true,
             "requires": {
-                "spdx-license-ids": "1.2.2"
+                "spdx-license-ids": "^1.0.2"
             }
         },
         "spdx-expression-parse": {
@@ -8860,12 +8860,12 @@
             "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "handle-thing": "1.2.5",
-                "http-deceiver": "1.2.7",
-                "safe-buffer": "5.1.1",
-                "select-hose": "2.0.0",
-                "spdy-transport": "2.0.20"
+                "debug": "^2.6.8",
+                "handle-thing": "^1.2.5",
+                "http-deceiver": "^1.2.7",
+                "safe-buffer": "^5.0.1",
+                "select-hose": "^2.0.0",
+                "spdy-transport": "^2.0.18"
             },
             "dependencies": {
                 "debug": {
@@ -8891,13 +8891,13 @@
             "integrity": "sha1-c15yBUxIayNU/onnAiVgBKOazk0=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "detect-node": "2.0.3",
-                "hpack.js": "2.1.6",
-                "obuf": "1.1.1",
-                "readable-stream": "2.3.3",
-                "safe-buffer": "5.1.1",
-                "wbuf": "1.7.2"
+                "debug": "^2.6.8",
+                "detect-node": "^2.0.3",
+                "hpack.js": "^2.1.6",
+                "obuf": "^1.1.1",
+                "readable-stream": "^2.2.9",
+                "safe-buffer": "^5.0.1",
+                "wbuf": "^1.7.2"
             },
             "dependencies": {
                 "debug": {
@@ -8927,13 +8927,13 @@
                     "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.0.3",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.0.3",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -8942,7 +8942,7 @@
                     "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -8959,15 +8959,15 @@
             "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
             "dev": true,
             "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "safer-buffer": "2.1.2",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -8990,8 +8990,8 @@
             "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3"
+                "inherits": "~2.0.1",
+                "readable-stream": "^2.0.2"
             },
             "dependencies": {
                 "isarray": {
@@ -9006,13 +9006,13 @@
                     "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.0.3",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.0.3",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -9021,7 +9021,7 @@
                     "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -9032,11 +9032,11 @@
             "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
             "dev": true,
             "requires": {
-                "builtin-status-codes": "3.0.0",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3",
-                "to-arraybuffer": "1.0.1",
-                "xtend": "4.0.1"
+                "builtin-status-codes": "^3.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.2.6",
+                "to-arraybuffer": "^1.0.0",
+                "xtend": "^4.0.0"
             },
             "dependencies": {
                 "isarray": {
@@ -9051,13 +9051,13 @@
                     "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.0.3",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.0.3",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -9066,7 +9066,7 @@
                     "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -9083,8 +9083,8 @@
             "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
             "dev": true,
             "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -9099,7 +9099,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 }
             }
@@ -9122,7 +9122,7 @@
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "strip-bom": {
@@ -9131,7 +9131,7 @@
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "dev": true,
             "requires": {
-                "is-utf8": "0.2.1"
+                "is-utf8": "^0.2.0"
             }
         },
         "strip-json-comments": {
@@ -9146,8 +9146,8 @@
             "integrity": "sha1-zDFFmvvNbYC3Ig7lSykan9Zv9es=",
             "dev": true,
             "requires": {
-                "loader-utils": "1.1.0",
-                "schema-utils": "0.3.0"
+                "loader-utils": "^1.0.2",
+                "schema-utils": "^0.3.0"
             },
             "dependencies": {
                 "loader-utils": {
@@ -9156,9 +9156,9 @@
                     "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
                     "dev": true,
                     "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1"
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0"
                     }
                 }
             }
@@ -9170,28 +9170,33 @@
             "dev": true
         },
         "svg-pan-zoom": {
-            "version": "github:ariutta/svg-pan-zoom#8a8319d52599bd2a66c64cbc2a3d948b045c971a"
+            "version": "github:ariutta/svg-pan-zoom#8a8319d52599bd2a66c64cbc2a3d948b045c971a",
+            "from": "github:ariutta/svg-pan-zoom#3.2.11"
         },
         "svg.draggable.js": {
             "version": "git+https://github.com/svgdotjs/svg.draggable.js.git#270179355df1b8989bf101227b8b953fea2d3ae1",
+            "from": "git+https://github.com/svgdotjs/svg.draggable.js.git#2.0.0",
             "requires": {
-                "svg.js": "git+https://github.com/svgdotjs/svg.js.git#dd826d235281883b5f5dd451535bc259688d08ba"
+                "svg.js": "^2.0.1"
             }
         },
         "svg.js": {
-            "version": "git+https://github.com/svgdotjs/svg.js.git#dd826d235281883b5f5dd451535bc259688d08ba"
+            "version": "git+https://github.com/svgdotjs/svg.js.git#dd826d235281883b5f5dd451535bc259688d08ba",
+            "from": "git+https://github.com/svgdotjs/svg.js.git#2.0.4"
         },
         "svg.resize.js": {
             "version": "git+https://github.com/parabolika66/svg.resize.js.git#96e9966d3b6f1bdd4c970e4fd548703b9b999d04",
+            "from": "git+https://github.com/parabolika66/svg.resize.js.git#1.1.3",
             "requires": {
-                "svg.js": "git+https://github.com/svgdotjs/svg.js.git#dd826d235281883b5f5dd451535bc259688d08ba",
-                "svg.select.js": "git+https://github.com/parabolika66/svg.select.js.git#587435e5664bdbf5860f718afbbbff0adf04baf3"
+                "svg.js": "^2.0.2",
+                "svg.select.js": "^1.0.4"
             }
         },
         "svg.select.js": {
             "version": "git+https://github.com/parabolika66/svg.select.js.git#587435e5664bdbf5860f718afbbbff0adf04baf3",
+            "from": "git+https://github.com/parabolika66/svg.select.js.git#1.0.8",
             "requires": {
-                "svg.js": "git+https://github.com/svgdotjs/svg.js.git#dd826d235281883b5f5dd451535bc259688d08ba"
+                "svg.js": "2.x.x"
             }
         },
         "svgo": {
@@ -9200,13 +9205,13 @@
             "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
             "dev": true,
             "requires": {
-                "coa": "1.0.4",
-                "colors": "1.1.2",
-                "csso": "2.3.2",
-                "js-yaml": "3.7.0",
-                "mkdirp": "0.5.1",
-                "sax": "1.2.4",
-                "whet.extend": "0.9.9"
+                "coa": "~1.0.1",
+                "colors": "~1.1.2",
+                "csso": "~2.3.1",
+                "js-yaml": "~3.7.0",
+                "mkdirp": "~0.5.1",
+                "sax": "~1.2.1",
+                "whet.extend": "~0.9.9"
             },
             "dependencies": {
                 "esprima": {
@@ -9221,8 +9226,8 @@
                     "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
                     "dev": true,
                     "requires": {
-                        "argparse": "1.0.9",
-                        "esprima": "2.7.3"
+                        "argparse": "^1.0.7",
+                        "esprima": "^2.6.0"
                     }
                 }
             }
@@ -9233,12 +9238,12 @@
             "integrity": "sha1-ozRHN1OR52atNNNIbm4q7chNLjY=",
             "dev": true,
             "requires": {
-                "ajv": "5.3.0",
-                "ajv-keywords": "2.1.1",
-                "chalk": "2.3.0",
-                "lodash": "4.17.4",
+                "ajv": "^5.2.3",
+                "ajv-keywords": "^2.1.0",
+                "chalk": "^2.1.0",
+                "lodash": "^4.17.4",
                 "slice-ansi": "1.0.0",
-                "string-width": "2.1.1"
+                "string-width": "^2.1.1"
             },
             "dependencies": {
                 "ajv": {
@@ -9247,10 +9252,10 @@
                     "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
                     "dev": true,
                     "requires": {
-                        "co": "4.6.0",
-                        "fast-deep-equal": "1.0.0",
-                        "fast-json-stable-stringify": "2.0.0",
-                        "json-schema-traverse": "0.3.1"
+                        "co": "^4.6.0",
+                        "fast-deep-equal": "^1.0.0",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.3.0"
                     }
                 },
                 "ansi-styles": {
@@ -9259,7 +9264,7 @@
                     "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.0"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -9268,9 +9273,9 @@
                     "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.0",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "4.5.0"
+                        "ansi-styles": "^3.1.0",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^4.0.0"
                     }
                 },
                 "lodash": {
@@ -9285,7 +9290,7 @@
                     "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -9320,7 +9325,7 @@
             "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
             "dev": true,
             "requires": {
-                "setimmediate": "1.0.5"
+                "setimmediate": "^1.0.4"
             }
         },
         "tmp": {
@@ -9329,7 +9334,7 @@
             "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
             "dev": true,
             "requires": {
-                "os-tmpdir": "1.0.2"
+                "os-tmpdir": "~1.0.1"
             }
         },
         "to-array": {
@@ -9356,7 +9361,7 @@
             "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
             "dev": true,
             "requires": {
-                "hoek": "6.1.2"
+                "hoek": "6.x.x"
             },
             "dependencies": {
                 "hoek": {
@@ -9379,7 +9384,7 @@
             "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
             "dev": true,
             "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.4.1"
             }
         },
         "trim-right": {
@@ -9405,10 +9410,10 @@
             "integrity": "sha512-AQmLFSIgTiR8AlS5BxqvoHpZ3OUTwHHuDZTAZ2KcKsYRz/yANGeQn4Se/DCQ4cn1/eVvN37f/caVW4+kUPNNHw==",
             "dev": true,
             "requires": {
-                "chalk": "2.3.0",
-                "enhanced-resolve": "3.4.1",
-                "loader-utils": "1.1.0",
-                "semver": "5.4.1"
+                "chalk": "^2.3.0",
+                "enhanced-resolve": "^3.0.0",
+                "loader-utils": "^1.0.2",
+                "semver": "^5.0.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9417,7 +9422,7 @@
                     "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.0"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -9426,9 +9431,9 @@
                     "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.0",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "4.5.0"
+                        "ansi-styles": "^3.1.0",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^4.0.0"
                     }
                 },
                 "loader-utils": {
@@ -9437,9 +9442,9 @@
                     "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
                     "dev": true,
                     "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1"
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0"
                     }
                 },
                 "supports-color": {
@@ -9448,7 +9453,7 @@
                     "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -9459,16 +9464,16 @@
             "integrity": "sha1-wTxqMCTjC+EYDdUwOPwgkonUv2k=",
             "dev": true,
             "requires": {
-                "arrify": "1.0.1",
-                "chalk": "2.3.0",
-                "diff": "3.4.0",
-                "make-error": "1.3.0",
-                "minimist": "1.2.0",
-                "mkdirp": "0.5.1",
-                "source-map-support": "0.4.18",
-                "tsconfig": "6.0.0",
-                "v8flags": "3.0.1",
-                "yn": "2.0.0"
+                "arrify": "^1.0.0",
+                "chalk": "^2.0.0",
+                "diff": "^3.1.0",
+                "make-error": "^1.1.1",
+                "minimist": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "source-map-support": "^0.4.0",
+                "tsconfig": "^6.0.0",
+                "v8flags": "^3.0.0",
+                "yn": "^2.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9477,7 +9482,7 @@
                     "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.0"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -9486,9 +9491,9 @@
                     "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.0",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "4.5.0"
+                        "ansi-styles": "^3.1.0",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^4.0.0"
                     }
                 },
                 "minimist": {
@@ -9503,7 +9508,7 @@
                     "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -9514,8 +9519,8 @@
             "integrity": "sha1-aw6DdgA9evGGT434+J3QBZ/80DI=",
             "dev": true,
             "requires": {
-                "strip-bom": "3.0.0",
-                "strip-json-comments": "2.0.1"
+                "strip-bom": "^3.0.0",
+                "strip-json-comments": "^2.0.0"
             },
             "dependencies": {
                 "strip-bom": {
@@ -9543,19 +9548,19 @@
             "integrity": "sha512-pflx87WfVoYepTet3xLfDOLDm9Jqi61UXIKePOuca0qoAZyrGWonDG9VTbji58Fy+8gciUn8Bt7y69+KEVjc/w==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "7.0.0",
-                "builtin-modules": "1.1.1",
-                "chalk": "2.4.2",
-                "commander": "2.12.1",
-                "diff": "3.4.0",
-                "glob": "7.1.2",
-                "js-yaml": "3.13.1",
-                "minimatch": "3.0.4",
-                "mkdirp": "0.5.1",
-                "resolve": "1.11.0",
-                "semver": "5.4.1",
-                "tslib": "1.9.3",
-                "tsutils": "2.29.0"
+                "@babel/code-frame": "^7.0.0",
+                "builtin-modules": "^1.1.1",
+                "chalk": "^2.3.0",
+                "commander": "^2.12.1",
+                "diff": "^3.2.0",
+                "glob": "^7.1.1",
+                "js-yaml": "^3.13.1",
+                "minimatch": "^3.0.4",
+                "mkdirp": "^0.5.1",
+                "resolve": "^1.3.2",
+                "semver": "^5.3.0",
+                "tslib": "^1.8.0",
+                "tsutils": "^2.29.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9564,7 +9569,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.0"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -9573,9 +9578,9 @@
                     "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.5.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "has-flag": {
@@ -9590,8 +9595,8 @@
                     "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
                     "dev": true,
                     "requires": {
-                        "argparse": "1.0.9",
-                        "esprima": "4.0.0"
+                        "argparse": "^1.0.7",
+                        "esprima": "^4.0.0"
                     }
                 },
                 "supports-color": {
@@ -9600,7 +9605,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -9611,7 +9616,7 @@
             "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
             "dev": true,
             "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.8.1"
             }
         },
         "tty-browserify": {
@@ -9626,7 +9631,7 @@
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "^5.0.1"
             }
         },
         "tv4": {
@@ -9643,7 +9648,8 @@
             "optional": true
         },
         "twigs": {
-            "version": "github:hatchteam/twigs#56cc40e2534b39dacb6f8b12a0b2303376972a20"
+            "version": "github:hatchteam/twigs#56cc40e2534b39dacb6f8b12a0b2303376972a20",
+            "from": "github:hatchteam/twigs#0.2.3"
         },
         "type-check": {
             "version": "0.3.2",
@@ -9651,7 +9657,7 @@
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
             "dev": true,
             "requires": {
-                "prelude-ls": "1.1.2"
+                "prelude-ls": "~1.1.2"
             }
         },
         "type-is": {
@@ -9661,7 +9667,7 @@
             "dev": true,
             "requires": {
                 "media-typer": "0.3.0",
-                "mime-types": "2.1.17"
+                "mime-types": "~2.1.15"
             }
         },
         "typedarray": {
@@ -9681,8 +9687,8 @@
             "integrity": "sha512-L98DlTshoPGnZGF8pr3MoE+CCo6n9joktHNHMPkckeBV8xTVc4CWtC0kGGhQsIvnX2Ug4nXFTAeE7SpTrPX2tg==",
             "dev": true,
             "requires": {
-                "commander": "2.12.1",
-                "source-map": "0.6.1"
+                "commander": "~2.12.1",
+                "source-map": "~0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -9718,7 +9724,7 @@
             "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
             "dev": true,
             "requires": {
-                "macaddress": "0.2.8"
+                "macaddress": "^0.2.8"
             }
         },
         "uniqs": {
@@ -9751,7 +9757,7 @@
             "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
             "dev": true,
             "requires": {
-                "punycode": "2.1.1"
+                "punycode": "^2.1.0"
             },
             "dependencies": {
                 "punycode": {
@@ -9786,8 +9792,8 @@
             "integrity": "sha1-zI/qgse5Bud3cBklCGnlaemVwpU=",
             "dev": true,
             "requires": {
-                "loader-utils": "1.1.0",
-                "mime": "1.3.4"
+                "loader-utils": "^1.0.2",
+                "mime": "1.3.x"
             },
             "dependencies": {
                 "loader-utils": {
@@ -9796,9 +9802,9 @@
                     "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
                     "dev": true,
                     "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1"
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0"
                     }
                 }
             }
@@ -9809,8 +9815,8 @@
             "integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
             "dev": true,
             "requires": {
-                "querystringify": "1.0.0",
-                "requires-port": "1.0.0"
+                "querystringify": "~1.0.0",
+                "requires-port": "~1.0.0"
             },
             "dependencies": {
                 "querystringify": {
@@ -9827,8 +9833,8 @@
             "integrity": "sha1-z1k+9PLRdYdei7ZY6pLhik/QbY4=",
             "dev": true,
             "requires": {
-                "lru-cache": "2.2.4",
-                "tmp": "0.0.30"
+                "lru-cache": "2.2.x",
+                "tmp": "0.0.x"
             },
             "dependencies": {
                 "lru-cache": {
@@ -9892,7 +9898,7 @@
             "integrity": "sha1-3Oj8N5wX2fLJ6e142JzgAFKxt2s=",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "1.0.1"
+                "homedir-polyfill": "^1.0.1"
             }
         },
         "validate-npm-package-license": {
@@ -9901,8 +9907,8 @@
             "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
             "dev": true,
             "requires": {
-                "spdx-correct": "1.0.2",
-                "spdx-expression-parse": "1.0.4"
+                "spdx-correct": "~1.0.0",
+                "spdx-expression-parse": "~1.0.0"
             }
         },
         "vary": {
@@ -9923,9 +9929,9 @@
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -9957,11 +9963,11 @@
             "integrity": "sha512-QUGNKlKLDyY6W/qHdxaRlXUAgLPe+3mLL/tRByHpRNcHs/c7dZXbu+OnJWGNux6tU1WFh/Z8aEwvbuzSAu79Zg==",
             "dev": true,
             "requires": {
-                "core-js": "2.6.4",
-                "joi": "13.7.0",
-                "minimist": "1.2.0",
-                "request": "2.88.0",
-                "rx": "4.1.0"
+                "core-js": "^2.5.7",
+                "joi": "^13.0.0",
+                "minimist": "^1.2.0",
+                "request": "^2.88.0",
+                "rx": "^4.1.0"
             },
             "dependencies": {
                 "ajv": {
@@ -9970,10 +9976,10 @@
                     "integrity": "sha512-eqxCp82P+JfqL683wwsL73XmFs1eG6qjw+RD3YHx+Jll1r0jNd4dh8QG9NYAeNGA/hnZjeEDgtTskgJULbxpWQ==",
                     "dev": true,
                     "requires": {
-                        "fast-deep-equal": "2.0.1",
-                        "fast-json-stable-stringify": "2.0.0",
-                        "json-schema-traverse": "0.4.1",
-                        "uri-js": "4.2.2"
+                        "fast-deep-equal": "^2.0.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
                     }
                 },
                 "assert-plus": {
@@ -10018,9 +10024,9 @@
                     "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
                     "dev": true,
                     "requires": {
-                        "asynckit": "0.4.0",
-                        "combined-stream": "1.0.6",
-                        "mime-types": "2.1.21"
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.6",
+                        "mime-types": "^2.1.12"
                     }
                 },
                 "har-schema": {
@@ -10035,8 +10041,8 @@
                     "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
                     "dev": true,
                     "requires": {
-                        "ajv": "6.8.1",
-                        "har-schema": "2.0.0"
+                        "ajv": "^6.5.5",
+                        "har-schema": "^2.0.0"
                     }
                 },
                 "http-signature": {
@@ -10045,9 +10051,9 @@
                     "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
                     "dev": true,
                     "requires": {
-                        "assert-plus": "1.0.0",
-                        "jsprim": "1.4.1",
-                        "sshpk": "1.14.2"
+                        "assert-plus": "^1.0.0",
+                        "jsprim": "^1.2.2",
+                        "sshpk": "^1.7.0"
                     }
                 },
                 "json-schema-traverse": {
@@ -10068,7 +10074,7 @@
                     "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
                     "dev": true,
                     "requires": {
-                        "mime-db": "1.37.0"
+                        "mime-db": "~1.37.0"
                     }
                 },
                 "oauth-sign": {
@@ -10095,26 +10101,26 @@
                     "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
                     "dev": true,
                     "requires": {
-                        "aws-sign2": "0.7.0",
-                        "aws4": "1.8.0",
-                        "caseless": "0.12.0",
-                        "combined-stream": "1.0.6",
-                        "extend": "3.0.2",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.3.3",
-                        "har-validator": "5.1.3",
-                        "http-signature": "1.2.0",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.21",
-                        "oauth-sign": "0.9.0",
-                        "performance-now": "2.1.0",
-                        "qs": "6.5.2",
-                        "safe-buffer": "5.1.2",
-                        "tough-cookie": "2.4.3",
-                        "tunnel-agent": "0.6.0",
-                        "uuid": "3.3.2"
+                        "aws-sign2": "~0.7.0",
+                        "aws4": "^1.8.0",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.6",
+                        "extend": "~3.0.2",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.3.2",
+                        "har-validator": "~5.1.0",
+                        "http-signature": "~1.2.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.19",
+                        "oauth-sign": "~0.9.0",
+                        "performance-now": "^2.1.0",
+                        "qs": "~6.5.2",
+                        "safe-buffer": "^5.1.2",
+                        "tough-cookie": "~2.4.3",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.3.2"
                     }
                 },
                 "safe-buffer": {
@@ -10129,8 +10135,8 @@
                     "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
                     "dev": true,
                     "requires": {
-                        "psl": "1.1.31",
-                        "punycode": "1.4.1"
+                        "psl": "^1.1.24",
+                        "punycode": "^1.4.1"
                     }
                 },
                 "uuid": {
@@ -10147,9 +10153,9 @@
             "integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
             "dev": true,
             "requires": {
-                "async": "2.6.0",
-                "chokidar": "1.7.0",
-                "graceful-fs": "4.1.3"
+                "async": "^2.1.2",
+                "chokidar": "^1.7.0",
+                "graceful-fs": "^4.1.2"
             },
             "dependencies": {
                 "async": {
@@ -10158,7 +10164,7 @@
                     "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
                     "dev": true,
                     "requires": {
-                        "lodash": "4.17.4"
+                        "lodash": "^4.14.0"
                     }
                 },
                 "lodash": {
@@ -10175,7 +10181,7 @@
             "integrity": "sha1-1pe5nx9ZUS3ydRvkJ2nBWAtYAf4=",
             "dev": true,
             "requires": {
-                "minimalistic-assert": "1.0.0"
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "webdriver-js-extender": {
@@ -10184,8 +10190,8 @@
             "integrity": "sha1-gcUzqeM9W/tZe05j4s2yW1R3dRU=",
             "dev": true,
             "requires": {
-                "@types/selenium-webdriver": "2.53.43",
-                "selenium-webdriver": "2.53.3"
+                "@types/selenium-webdriver": "^2.53.35",
+                "selenium-webdriver": "^2.53.2"
             },
             "dependencies": {
                 "sax": {
@@ -10201,9 +10207,9 @@
                     "dev": true,
                     "requires": {
                         "adm-zip": "0.4.4",
-                        "rimraf": "2.6.2",
+                        "rimraf": "^2.2.8",
                         "tmp": "0.0.24",
-                        "ws": "1.1.5",
+                        "ws": "^1.0.1",
                         "xml2js": "0.4.4"
                     }
                 },
@@ -10219,9 +10225,205 @@
                     "integrity": "sha1-MREBAAMAiuGSQOuhdJe1fHKcVV0=",
                     "dev": true,
                     "requires": {
-                        "sax": "0.6.1",
-                        "xmlbuilder": "8.2.2"
+                        "sax": "0.6.x",
+                        "xmlbuilder": ">=1.0.0"
                     }
+                }
+            }
+        },
+        "webdriver-manager": {
+            "version": "12.1.7",
+            "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-12.1.7.tgz",
+            "integrity": "sha512-XINj6b8CYuUYC93SG3xPkxlyUc3IJbD6Vvo75CVGuG9uzsefDzWQrhz0Lq8vbPxtb4d63CZdYophF8k8Or/YiA==",
+            "dev": true,
+            "requires": {
+                "adm-zip": "^0.4.9",
+                "chalk": "^1.1.1",
+                "del": "^2.2.0",
+                "glob": "^7.0.3",
+                "ini": "^1.3.4",
+                "minimist": "^1.2.0",
+                "q": "^1.4.1",
+                "request": "^2.87.0",
+                "rimraf": "^2.5.2",
+                "semver": "^5.3.0",
+                "xml2js": "^0.4.17"
+            },
+            "dependencies": {
+                "adm-zip": {
+                    "version": "0.4.13",
+                    "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
+                    "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw==",
+                    "dev": true
+                },
+                "ajv": {
+                    "version": "6.10.2",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+                    "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^2.0.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                },
+                "aws-sign2": {
+                    "version": "0.7.0",
+                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+                    "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+                    "dev": true
+                },
+                "aws4": {
+                    "version": "1.8.0",
+                    "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+                    "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+                    "dev": true
+                },
+                "extend": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+                    "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+                    "dev": true
+                },
+                "fast-deep-equal": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+                    "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+                    "dev": true
+                },
+                "form-data": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+                    "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+                    "dev": true,
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.6",
+                        "mime-types": "^2.1.12"
+                    }
+                },
+                "har-schema": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+                    "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+                    "dev": true
+                },
+                "har-validator": {
+                    "version": "5.1.3",
+                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+                    "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^6.5.5",
+                        "har-schema": "^2.0.0"
+                    }
+                },
+                "http-signature": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+                    "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "^1.0.0",
+                        "jsprim": "^1.2.2",
+                        "sshpk": "^1.7.0"
+                    }
+                },
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+                    "dev": true
+                },
+                "mime-db": {
+                    "version": "1.40.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+                    "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+                    "dev": true
+                },
+                "mime-types": {
+                    "version": "2.1.24",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+                    "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+                    "dev": true,
+                    "requires": {
+                        "mime-db": "1.40.0"
+                    }
+                },
+                "oauth-sign": {
+                    "version": "0.9.0",
+                    "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+                    "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+                    "dev": true
+                },
+                "performance-now": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+                    "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+                    "dev": true
+                },
+                "qs": {
+                    "version": "6.5.2",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+                    "dev": true
+                },
+                "request": {
+                    "version": "2.88.0",
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+                    "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+                    "dev": true,
+                    "requires": {
+                        "aws-sign2": "~0.7.0",
+                        "aws4": "^1.8.0",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.6",
+                        "extend": "~3.0.2",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.3.2",
+                        "har-validator": "~5.1.0",
+                        "http-signature": "~1.2.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.19",
+                        "oauth-sign": "~0.9.0",
+                        "performance-now": "^2.1.0",
+                        "qs": "~6.5.2",
+                        "safe-buffer": "^5.1.2",
+                        "tough-cookie": "~2.4.3",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.3.2"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+                    "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+                    "dev": true
+                },
+                "tough-cookie": {
+                    "version": "2.4.3",
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+                    "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+                    "dev": true,
+                    "requires": {
+                        "psl": "^1.1.24",
+                        "punycode": "^1.4.1"
+                    }
+                },
+                "uuid": {
+                    "version": "3.3.3",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+                    "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+                    "dev": true
                 }
             }
         },
@@ -10231,27 +10433,27 @@
             "integrity": "sha1-WhcIn40OQ0QuYG1s+bKhRsjtmRE=",
             "dev": true,
             "requires": {
-                "acorn": "5.2.1",
-                "acorn-dynamic-import": "2.0.2",
-                "ajv": "4.11.8",
-                "ajv-keywords": "1.5.1",
-                "async": "2.6.0",
-                "enhanced-resolve": "3.4.1",
-                "interpret": "1.0.4",
-                "json-loader": "0.5.7",
-                "json5": "0.5.1",
-                "loader-runner": "2.3.0",
-                "loader-utils": "0.2.17",
-                "memory-fs": "0.4.1",
-                "mkdirp": "0.5.1",
-                "node-libs-browser": "2.1.0",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3",
-                "tapable": "0.2.8",
-                "uglify-js": "2.8.29",
-                "watchpack": "1.4.0",
-                "webpack-sources": "0.2.3",
-                "yargs": "6.6.0"
+                "acorn": "^5.0.0",
+                "acorn-dynamic-import": "^2.0.0",
+                "ajv": "^4.7.0",
+                "ajv-keywords": "^1.1.1",
+                "async": "^2.1.2",
+                "enhanced-resolve": "^3.0.0",
+                "interpret": "^1.0.0",
+                "json-loader": "^0.5.4",
+                "json5": "^0.5.1",
+                "loader-runner": "^2.3.0",
+                "loader-utils": "^0.2.16",
+                "memory-fs": "~0.4.1",
+                "mkdirp": "~0.5.0",
+                "node-libs-browser": "^2.0.0",
+                "source-map": "^0.5.3",
+                "supports-color": "^3.1.0",
+                "tapable": "~0.2.5",
+                "uglify-js": "^2.8.5",
+                "watchpack": "^1.3.1",
+                "webpack-sources": "^0.2.3",
+                "yargs": "^6.0.0"
             },
             "dependencies": {
                 "ajv": {
@@ -10260,8 +10462,8 @@
                     "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
                     "dev": true,
                     "requires": {
-                        "co": "4.6.0",
-                        "json-stable-stringify": "1.0.1"
+                        "co": "^4.6.0",
+                        "json-stable-stringify": "^1.0.1"
                     }
                 },
                 "ajv-keywords": {
@@ -10276,7 +10478,7 @@
                     "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
                     "dev": true,
                     "requires": {
-                        "lodash": "4.17.4"
+                        "lodash": "^4.14.0"
                     }
                 },
                 "has-flag": {
@@ -10297,7 +10499,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 },
                 "uglify-js": {
@@ -10306,9 +10508,9 @@
                     "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
                     "dev": true,
                     "requires": {
-                        "source-map": "0.5.7",
-                        "uglify-to-browserify": "1.0.2",
-                        "yargs": "3.10.0"
+                        "source-map": "~0.5.1",
+                        "uglify-to-browserify": "~1.0.0",
+                        "yargs": "~3.10.0"
                     },
                     "dependencies": {
                         "yargs": {
@@ -10317,9 +10519,9 @@
                             "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
                             "dev": true,
                             "requires": {
-                                "camelcase": "1.2.1",
-                                "cliui": "2.1.0",
-                                "decamelize": "1.2.0",
+                                "camelcase": "^1.0.2",
+                                "cliui": "^2.1.0",
+                                "decamelize": "^1.0.0",
                                 "window-size": "0.1.0"
                             }
                         }
@@ -10333,11 +10535,11 @@
             "integrity": "sha512-UzyVg/CKBKkymDpqOoQ4mWTs9zQp0DPCY8zbol9K0tPhqoM+JU5knKGXyMQ/Cdrmzb9Cw3eetm67fIsJ7u7ryg==",
             "dev": true,
             "requires": {
-                "memory-fs": "0.4.1",
-                "mime": "1.6.0",
-                "path-is-absolute": "1.0.1",
-                "range-parser": "1.2.0",
-                "time-stamp": "2.0.0"
+                "memory-fs": "~0.4.1",
+                "mime": "^1.4.1",
+                "path-is-absolute": "^1.0.0",
+                "range-parser": "^1.0.3",
+                "time-stamp": "^2.0.0"
             },
             "dependencies": {
                 "mime": {
@@ -10355,22 +10557,22 @@
             "dev": true,
             "requires": {
                 "ansi-html": "0.0.7",
-                "chokidar": "1.7.0",
-                "compression": "1.7.1",
-                "connect-history-api-fallback": "1.5.0",
-                "express": "4.16.2",
-                "html-entities": "1.2.1",
-                "http-proxy-middleware": "0.17.4",
+                "chokidar": "^1.6.0",
+                "compression": "^1.5.2",
+                "connect-history-api-fallback": "^1.3.0",
+                "express": "^4.13.3",
+                "html-entities": "^1.2.0",
+                "http-proxy-middleware": "~0.17.4",
                 "opn": "4.0.2",
-                "portfinder": "1.0.13",
-                "serve-index": "1.9.1",
+                "portfinder": "^1.0.9",
+                "serve-index": "^1.7.2",
                 "sockjs": "0.3.18",
                 "sockjs-client": "1.1.2",
-                "spdy": "3.4.7",
-                "strip-ansi": "3.0.1",
-                "supports-color": "3.2.3",
-                "webpack-dev-middleware": "1.12.1",
-                "yargs": "6.6.0"
+                "spdy": "^3.4.1",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^3.1.1",
+                "webpack-dev-middleware": "^1.10.2",
+                "yargs": "^6.0.0"
             },
             "dependencies": {
                 "has-flag": {
@@ -10385,7 +10587,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -10396,7 +10598,7 @@
             "integrity": "sha1-atciI7PguDflMeRZfBmfkJNhUR4=",
             "dev": true,
             "requires": {
-                "lodash": "4.17.4"
+                "lodash": "^4.17.4"
             },
             "dependencies": {
                 "lodash": {
@@ -10413,8 +10615,8 @@
             "integrity": "sha1-F8Yr+vE8cH+dAsR54Nzd6DgGl/s=",
             "dev": true,
             "requires": {
-                "source-list-map": "1.1.2",
-                "source-map": "0.5.7"
+                "source-list-map": "^1.1.1",
+                "source-map": "~0.5.3"
             },
             "dependencies": {
                 "source-list-map": {
@@ -10431,8 +10633,8 @@
             "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
             "dev": true,
             "requires": {
-                "http-parser-js": "0.4.9",
-                "websocket-extensions": "0.1.3"
+                "http-parser-js": ">=0.4.0",
+                "websocket-extensions": ">=0.1.1"
             }
         },
         "websocket-extensions": {
@@ -10453,7 +10655,7 @@
             "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
             "dev": true,
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "which-module": {
@@ -10480,8 +10682,8 @@
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "dev": true,
             "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
             },
             "dependencies": {
                 "is-fullwidth-code-point": {
@@ -10490,7 +10692,7 @@
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "string-width": {
@@ -10499,9 +10701,9 @@
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                     "dev": true,
                     "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                     }
                 }
             }
@@ -10518,7 +10720,7 @@
             "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
             "dev": true,
             "requires": {
-                "mkdirp": "0.5.1"
+                "mkdirp": "^0.5.1"
             }
         },
         "ws": {
@@ -10527,8 +10729,8 @@
             "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
             "dev": true,
             "requires": {
-                "options": "0.0.6",
-                "ultron": "1.0.2"
+                "options": ">=0.0.5",
+                "ultron": "1.0.x"
             }
         },
         "xml-char-classes": {
@@ -10543,8 +10745,8 @@
             "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
             "dev": true,
             "requires": {
-                "sax": "1.2.4",
-                "xmlbuilder": "9.0.7"
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~9.0.1"
             },
             "dependencies": {
                 "xmlbuilder": {
@@ -10603,19 +10805,19 @@
             "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
             "dev": true,
             "requires": {
-                "camelcase": "3.0.0",
-                "cliui": "3.2.0",
-                "decamelize": "1.2.0",
-                "get-caller-file": "1.0.2",
-                "os-locale": "1.4.0",
-                "read-pkg-up": "1.0.1",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "1.0.2",
-                "which-module": "1.0.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "4.2.1"
+                "camelcase": "^3.0.0",
+                "cliui": "^3.2.0",
+                "decamelize": "^1.1.1",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^1.4.0",
+                "read-pkg-up": "^1.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^1.0.2",
+                "which-module": "^1.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^4.2.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -10630,9 +10832,9 @@
                     "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
                     "dev": true,
                     "requires": {
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wrap-ansi": "2.1.0"
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wrap-ansi": "^2.0.0"
                     }
                 },
                 "is-fullwidth-code-point": {
@@ -10641,7 +10843,7 @@
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "string-width": {
@@ -10650,9 +10852,9 @@
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                     "dev": true,
                     "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                     }
                 }
             }
@@ -10663,7 +10865,7 @@
             "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
             "dev": true,
             "requires": {
-                "camelcase": "3.0.0"
+                "camelcase": "^3.0.0"
             },
             "dependencies": {
                 "camelcase": {

--- a/scenarioo-client/package-lock.json
+++ b/scenarioo-client/package-lock.json
@@ -255,9 +255,9 @@
             }
         },
         "@types/node": {
-            "version": "6.0.113",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.113.tgz",
-            "integrity": "sha512-f9XXUWFqryzjkZA1EqFvJHSFyqyasV17fq8zCDIzbRV4ctL7RrJGKvG+lcex86Rjbzd1GrER9h9VmF5sSjV0BQ==",
+            "version": "6.14.7",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.7.tgz",
+            "integrity": "sha512-YbPXbaynBTe0pVExPhL76TsWnxSPeFAvImIsmylpBWn/yfw+lHy+Q68aawvZHsgskT44ZAoeE67GM5f+Brekew==",
             "dev": true
         },
         "@types/q": {
@@ -352,9 +352,9 @@
             "dev": true
         },
         "agent-base": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
-            "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+            "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
             "dev": true,
             "requires": {
                 "es6-promisify": "^5.0.0"
@@ -575,7 +575,8 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
             "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "async": {
             "version": "0.9.2",
@@ -613,13 +614,15 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
             "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "aws4": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
             "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "babel-code-frame": {
             "version": "6.26.0",
@@ -1514,14 +1517,6 @@
             "dev": true,
             "requires": {
                 "minimist": "^1.2.0"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                }
             }
         },
         "bluebird": {
@@ -2380,6 +2375,7 @@
             "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
             "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "boom": "2.x.x"
             }
@@ -2577,6 +2573,15 @@
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
             "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
             "dev": true
+        },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "dev": true,
+            "requires": {
+                "object-keys": "^1.0.12"
+            }
         },
         "defined": {
             "version": "1.0.0",
@@ -2940,10 +2945,50 @@
                 "is-arrayish": "^0.2.1"
             }
         },
+        "es-abstract": {
+            "version": "1.14.2",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.2.tgz",
+            "integrity": "sha512-DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==",
+            "dev": true,
+            "requires": {
+                "es-to-primitive": "^1.2.0",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.0",
+                "is-callable": "^1.1.4",
+                "is-regex": "^1.0.4",
+                "object-inspect": "^1.6.0",
+                "object-keys": "^1.1.1",
+                "string.prototype.trimleft": "^2.0.0",
+                "string.prototype.trimright": "^2.0.0"
+            },
+            "dependencies": {
+                "has": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+                    "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+                    "dev": true,
+                    "requires": {
+                        "function-bind": "^1.1.1"
+                    }
+                }
+            }
+        },
+        "es-to-primitive": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+            "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+            "dev": true,
+            "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            }
+        },
         "es6-promise": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
-            "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
+            "version": "4.2.8",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
             "dev": true
         },
         "es6-promisify": {
@@ -3608,6 +3653,7 @@
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
             "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.5",
@@ -3654,13 +3700,15 @@
             "dependencies": {
                 "abbrev": {
                     "version": "1.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+                    "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
                     "dev": true,
                     "optional": true
                 },
                 "ajv": {
                     "version": "4.11.8",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+                    "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3670,18 +3718,21 @@
                 },
                 "ansi-regex": {
                     "version": "2.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                     "dev": true
                 },
                 "aproba": {
                     "version": "1.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+                    "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
                     "dev": true,
                     "optional": true
                 },
                 "are-we-there-yet": {
                     "version": "1.1.4",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+                    "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3691,42 +3742,49 @@
                 },
                 "asn1": {
                     "version": "0.2.3",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                    "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
                     "dev": true,
                     "optional": true
                 },
                 "assert-plus": {
                     "version": "0.2.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                    "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
                     "dev": true,
                     "optional": true
                 },
                 "asynckit": {
                     "version": "0.4.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                    "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
                     "dev": true,
                     "optional": true
                 },
                 "aws-sign2": {
                     "version": "0.6.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                    "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
                     "dev": true,
                     "optional": true
                 },
                 "aws4": {
                     "version": "1.6.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+                    "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
                     "dev": true,
                     "optional": true
                 },
                 "balanced-match": {
                     "version": "0.4.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                    "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
                     "dev": true
                 },
                 "bcrypt-pbkdf": {
                     "version": "1.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+                    "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3735,7 +3793,8 @@
                 },
                 "block-stream": {
                     "version": "0.0.9",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+                    "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
                     "dev": true,
                     "requires": {
                         "inherits": "~2.0.0"
@@ -3743,7 +3802,8 @@
                 },
                 "boom": {
                     "version": "2.10.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                    "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
                     "dev": true,
                     "requires": {
                         "hoek": "2.x.x"
@@ -3751,7 +3811,8 @@
                 },
                 "brace-expansion": {
                     "version": "1.1.7",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+                    "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
                     "dev": true,
                     "requires": {
                         "balanced-match": "^0.4.1",
@@ -3760,29 +3821,34 @@
                 },
                 "buffer-shims": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+                    "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
                     "dev": true
                 },
                 "caseless": {
                     "version": "0.12.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+                    "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
                     "dev": true,
                     "optional": true
                 },
                 "co": {
                     "version": "4.6.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+                    "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
                     "dev": true,
                     "optional": true
                 },
                 "code-point-at": {
                     "version": "1.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                    "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                     "dev": true
                 },
                 "combined-stream": {
                     "version": "1.0.5",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                    "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
                     "dev": true,
                     "requires": {
                         "delayed-stream": "~1.0.0"
@@ -3790,22 +3856,26 @@
                 },
                 "concat-map": {
                     "version": "0.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                    "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                     "dev": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+                    "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
                     "dev": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                    "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                     "dev": true
                 },
                 "cryptiles": {
                     "version": "2.0.5",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                    "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
                     "dev": true,
                     "requires": {
                         "boom": "2.x.x"
@@ -3813,7 +3883,8 @@
                 },
                 "dashdash": {
                     "version": "1.14.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                    "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3822,7 +3893,8 @@
                     "dependencies": {
                         "assert-plus": {
                             "version": "1.0.0",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                             "dev": true,
                             "optional": true
                         }
@@ -3830,7 +3902,8 @@
                 },
                 "debug": {
                     "version": "2.6.8",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                    "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3839,30 +3912,35 @@
                 },
                 "deep-extend": {
                     "version": "0.4.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+                    "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
                     "dev": true,
                     "optional": true
                 },
                 "delayed-stream": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                    "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
                     "dev": true
                 },
                 "delegates": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                    "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                     "dev": true,
                     "optional": true
                 },
                 "detect-libc": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz",
+                    "integrity": "sha1-ca1dIEvxempsqPRQxhRUBm70YeE=",
                     "dev": true,
                     "optional": true
                 },
                 "ecc-jsbn": {
                     "version": "0.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                    "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3871,24 +3949,28 @@
                 },
                 "extend": {
                     "version": "3.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+                    "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
                     "dev": true,
                     "optional": true
                 },
                 "extsprintf": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                    "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
                     "dev": true
                 },
                 "forever-agent": {
                     "version": "0.6.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                    "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
                     "dev": true,
                     "optional": true
                 },
                 "form-data": {
                     "version": "2.1.4",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+                    "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3899,12 +3981,14 @@
                 },
                 "fs.realpath": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                    "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                     "dev": true
                 },
                 "fstream": {
                     "version": "1.0.11",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+                    "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
                     "dev": true,
                     "requires": {
                         "graceful-fs": "^4.1.2",
@@ -3915,7 +3999,8 @@
                 },
                 "fstream-ignore": {
                     "version": "1.0.5",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+                    "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3926,7 +4011,8 @@
                 },
                 "gauge": {
                     "version": "2.7.4",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+                    "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3942,7 +4028,8 @@
                 },
                 "getpass": {
                     "version": "0.1.7",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+                    "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3951,7 +4038,8 @@
                     "dependencies": {
                         "assert-plus": {
                             "version": "1.0.0",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                             "dev": true,
                             "optional": true
                         }
@@ -3959,7 +4047,8 @@
                 },
                 "glob": {
                     "version": "7.1.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "dev": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -3972,18 +4061,21 @@
                 },
                 "graceful-fs": {
                     "version": "4.1.11",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                    "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
                     "dev": true
                 },
                 "har-schema": {
                     "version": "1.0.5",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+                    "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
                     "dev": true,
                     "optional": true
                 },
                 "har-validator": {
                     "version": "4.2.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+                    "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3993,13 +4085,15 @@
                 },
                 "has-unicode": {
                     "version": "2.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+                    "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
                     "dev": true,
                     "optional": true
                 },
                 "hawk": {
                     "version": "3.1.3",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                    "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
                     "dev": true,
                     "requires": {
                         "boom": "2.x.x",
@@ -4010,12 +4104,14 @@
                 },
                 "hoek": {
                     "version": "2.16.3",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                    "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
                     "dev": true
                 },
                 "http-signature": {
                     "version": "1.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                    "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4026,7 +4122,8 @@
                 },
                 "inflight": {
                     "version": "1.0.6",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                    "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                     "dev": true,
                     "requires": {
                         "once": "^1.3.0",
@@ -4035,18 +4132,21 @@
                 },
                 "inherits": {
                     "version": "2.0.3",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
                     "dev": true
                 },
                 "ini": {
                     "version": "1.3.4",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+                    "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
                     "dev": true,
                     "optional": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "dev": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
@@ -4054,24 +4154,28 @@
                 },
                 "is-typedarray": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+                    "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
                     "dev": true,
                     "optional": true
                 },
                 "isarray": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                     "dev": true
                 },
                 "isstream": {
                     "version": "0.1.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                    "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
                     "dev": true,
                     "optional": true
                 },
                 "jodid25519": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                    "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4080,19 +4184,22 @@
                 },
                 "jsbn": {
                     "version": "0.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+                    "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
                     "dev": true,
                     "optional": true
                 },
                 "json-schema": {
                     "version": "0.2.3",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                    "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
                     "dev": true,
                     "optional": true
                 },
                 "json-stable-stringify": {
                     "version": "1.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                    "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4101,19 +4208,22 @@
                 },
                 "json-stringify-safe": {
                     "version": "5.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                    "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
                     "dev": true,
                     "optional": true
                 },
                 "jsonify": {
                     "version": "0.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                    "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
                     "dev": true,
                     "optional": true
                 },
                 "jsprim": {
                     "version": "1.4.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+                    "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4125,7 +4235,8 @@
                     "dependencies": {
                         "assert-plus": {
                             "version": "1.0.0",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                             "dev": true,
                             "optional": true
                         }
@@ -4133,12 +4244,14 @@
                 },
                 "mime-db": {
                     "version": "1.27.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+                    "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
                     "dev": true
                 },
                 "mime-types": {
                     "version": "2.1.15",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+                    "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
                     "dev": true,
                     "requires": {
                         "mime-db": "~1.27.0"
@@ -4146,7 +4259,8 @@
                 },
                 "minimatch": {
                     "version": "3.0.4",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                     "dev": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
@@ -4154,12 +4268,14 @@
                 },
                 "minimist": {
                     "version": "0.0.8",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                     "dev": true
                 },
                 "mkdirp": {
                     "version": "0.5.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                    "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                     "dev": true,
                     "requires": {
                         "minimist": "0.0.8"
@@ -4167,13 +4283,15 @@
                 },
                 "ms": {
                     "version": "2.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                     "dev": true,
                     "optional": true
                 },
                 "node-pre-gyp": {
                     "version": "0.6.39",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
+                    "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4192,7 +4310,8 @@
                 },
                 "nopt": {
                     "version": "4.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+                    "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4202,7 +4321,8 @@
                 },
                 "npmlog": {
                     "version": "4.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+                    "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4214,24 +4334,28 @@
                 },
                 "number-is-nan": {
                     "version": "1.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                    "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                     "dev": true
                 },
                 "oauth-sign": {
                     "version": "0.8.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+                    "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
                     "dev": true,
                     "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                     "dev": true,
                     "optional": true
                 },
                 "once": {
                     "version": "1.4.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                    "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                     "dev": true,
                     "requires": {
                         "wrappy": "1"
@@ -4239,19 +4363,22 @@
                 },
                 "os-homedir": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+                    "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
                     "dev": true,
                     "optional": true
                 },
                 "os-tmpdir": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+                    "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
                     "dev": true,
                     "optional": true
                 },
                 "osenv": {
                     "version": "0.1.4",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+                    "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4261,35 +4388,41 @@
                 },
                 "path-is-absolute": {
                     "version": "1.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                    "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                     "dev": true
                 },
                 "performance-now": {
                     "version": "0.2.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+                    "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
                     "dev": true,
                     "optional": true
                 },
                 "process-nextick-args": {
                     "version": "1.0.7",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                    "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
                     "dev": true
                 },
                 "punycode": {
                     "version": "1.4.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
                     "dev": true,
                     "optional": true
                 },
                 "qs": {
                     "version": "6.4.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+                    "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
                     "dev": true,
                     "optional": true
                 },
                 "rc": {
                     "version": "1.2.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+                    "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4301,7 +4434,8 @@
                     "dependencies": {
                         "minimist": {
                             "version": "1.2.0",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                             "dev": true,
                             "optional": true
                         }
@@ -4309,7 +4443,8 @@
                 },
                 "readable-stream": {
                     "version": "2.2.9",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+                    "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
                     "dev": true,
                     "requires": {
                         "buffer-shims": "~1.0.0",
@@ -4323,7 +4458,8 @@
                 },
                 "request": {
                     "version": "2.81.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+                    "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4353,7 +4489,8 @@
                 },
                 "rimraf": {
                     "version": "2.6.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+                    "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
                     "dev": true,
                     "requires": {
                         "glob": "^7.0.5"
@@ -4361,30 +4498,35 @@
                 },
                 "safe-buffer": {
                     "version": "5.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+                    "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
                     "dev": true
                 },
                 "semver": {
                     "version": "5.3.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+                    "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
                     "dev": true,
                     "optional": true
                 },
                 "set-blocking": {
                     "version": "2.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+                    "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                     "dev": true,
                     "optional": true
                 },
                 "signal-exit": {
                     "version": "3.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+                    "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                     "dev": true,
                     "optional": true
                 },
                 "sntp": {
                     "version": "1.0.9",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                    "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
                     "dev": true,
                     "requires": {
                         "hoek": "2.x.x"
@@ -4392,7 +4534,8 @@
                 },
                 "sshpk": {
                     "version": "1.13.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+                    "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4409,7 +4552,8 @@
                     "dependencies": {
                         "assert-plus": {
                             "version": "1.0.0",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                             "dev": true,
                             "optional": true
                         }
@@ -4417,7 +4561,8 @@
                 },
                 "string-width": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                     "dev": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
@@ -4427,7 +4572,8 @@
                 },
                 "string_decoder": {
                     "version": "1.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+                    "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
                     "dev": true,
                     "requires": {
                         "safe-buffer": "^5.0.1"
@@ -4435,13 +4581,15 @@
                 },
                 "stringstream": {
                     "version": "0.0.5",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                    "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
                     "dev": true,
                     "optional": true
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
@@ -4449,13 +4597,15 @@
                 },
                 "strip-json-comments": {
                     "version": "2.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+                    "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                     "dev": true,
                     "optional": true
                 },
                 "tar": {
                     "version": "2.2.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+                    "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
                     "dev": true,
                     "requires": {
                         "block-stream": "*",
@@ -4465,7 +4615,8 @@
                 },
                 "tar-pack": {
                     "version": "3.4.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+                    "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4481,7 +4632,8 @@
                 },
                 "tough-cookie": {
                     "version": "2.3.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+                    "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4490,7 +4642,8 @@
                 },
                 "tunnel-agent": {
                     "version": "0.6.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+                    "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4499,30 +4652,35 @@
                 },
                 "tweetnacl": {
                     "version": "0.14.5",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+                    "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
                     "dev": true,
                     "optional": true
                 },
                 "uid-number": {
                     "version": "0.0.6",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+                    "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
                     "dev": true,
                     "optional": true
                 },
                 "util-deprecate": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                    "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                     "dev": true
                 },
                 "uuid": {
                     "version": "3.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+                    "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
                     "dev": true,
                     "optional": true
                 },
                 "verror": {
                     "version": "1.3.6",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                    "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4531,7 +4689,8 @@
                 },
                 "wide-align": {
                     "version": "1.1.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+                    "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4540,7 +4699,8 @@
                 },
                 "wrappy": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                    "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                     "dev": true
                 }
             }
@@ -4753,13 +4913,15 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
             "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "har-validator": {
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
             "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "ajv": "^4.9.1",
                 "har-schema": "^1.0.5"
@@ -4770,6 +4932,7 @@
                     "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
                     "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "co": "^4.6.0",
                         "json-stable-stringify": "^1.0.1"
@@ -4816,6 +4979,12 @@
             "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
             "dev": true
         },
+        "has-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+            "dev": true
+        },
         "hash-base": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
@@ -4840,6 +5009,7 @@
             "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
             "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "boom": "2.x.x",
                 "cryptiles": "2.x.x",
@@ -5070,6 +5240,7 @@
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
             "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "assert-plus": "^0.2.0",
                 "jsprim": "^1.2.2",
@@ -5083,28 +5254,28 @@
             "dev": true
         },
         "https-proxy-agent": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-            "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
+            "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
             "dev": true,
             "requires": {
-                "agent-base": "^4.1.0",
+                "agent-base": "^4.3.0",
                 "debug": "^3.1.0"
             },
             "dependencies": {
                 "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "2.0.0"
+                        "ms": "^2.1.1"
                     }
                 },
                 "ms": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
                     "dev": true
                 }
             }
@@ -5328,6 +5499,18 @@
                 "builtin-modules": "^1.0.0"
             }
         },
+        "is-callable": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+            "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+            "dev": true
+        },
+        "is-date-object": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+            "dev": true
+        },
         "is-dotfile": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
@@ -5436,6 +5619,15 @@
             "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
             "dev": true
         },
+        "is-regex": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+            "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+            "dev": true,
+            "requires": {
+                "has": "^1.0.1"
+            }
+        },
         "is-resolvable": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
@@ -5452,6 +5644,15 @@
             "dev": true,
             "requires": {
                 "html-comment-regex": "^1.1.0"
+            }
+        },
+        "is-symbol": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+            "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+            "dev": true,
+            "requires": {
+                "has-symbols": "^1.0.0"
             }
         },
         "is-typedarray": {
@@ -5740,48 +5941,51 @@
             }
         },
         "jszip": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
-            "integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.2.2.tgz",
+            "integrity": "sha512-NmKajvAFQpbg3taXQXr/ccS2wcucR1AZ+NtyWp2Nq7HHVsXhcJFR8p0Baf32C2yVvBylFWVeKf+WI2AnvlPhpA==",
             "dev": true,
             "requires": {
-                "core-js": "~2.3.0",
-                "es6-promise": "~3.0.2",
-                "lie": "~3.1.0",
+                "lie": "~3.3.0",
                 "pako": "~1.0.2",
-                "readable-stream": "~2.0.6"
+                "readable-stream": "~2.3.6",
+                "set-immediate-shim": "~1.0.1"
             },
             "dependencies": {
-                "core-js": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
-                    "integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU=",
-                    "dev": true
-                },
-                "es6-promise": {
-                    "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
-                    "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y=",
-                    "dev": true
-                },
                 "isarray": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                     "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                     "dev": true
                 },
+                "process-nextick-args": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+                    "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+                    "dev": true
+                },
                 "readable-stream": {
-                    "version": "2.0.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                    "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
+                        "inherits": "~2.0.3",
                         "isarray": "~1.0.0",
-                        "process-nextick-args": "~1.0.6",
-                        "string_decoder": "~0.10.x",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
                         "util-deprecate": "~1.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -5964,9 +6168,9 @@
             }
         },
         "lie": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
-            "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+            "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
             "dev": true,
             "requires": {
                 "immediate": "~3.0.5"
@@ -6565,7 +6769,8 @@
             "version": "0.8.2",
             "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
             "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "object-assign": {
             "version": "4.1.1",
@@ -6578,6 +6783,28 @@
             "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
             "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
             "dev": true
+        },
+        "object-inspect": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+            "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+            "dev": true
+        },
+        "object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true
+        },
+        "object.getownpropertydescriptors": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+            "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.5.1"
+            }
         },
         "object.omit": {
             "version": "2.0.1",
@@ -6932,7 +7159,8 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
             "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "pify": {
             "version": "2.3.0",
@@ -7624,31 +7852,194 @@
             },
             "dependencies": {
                 "adm-zip": {
-                    "version": "0.4.11",
-                    "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.11.tgz",
-                    "integrity": "sha512-L8vcjDTCOIJk7wFvmlEUN7AsSb8T+2JrdP7KINBjzr24TJ5Mwj590sLu3BC7zNZowvJWa/JtPmD8eJCzdtDWjA==",
+                    "version": "0.4.13",
+                    "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
+                    "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw==",
                     "dev": true
                 },
-                "minimist": {
+                "ajv": {
+                    "version": "6.10.2",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+                    "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^2.0.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                },
+                "aws-sign2": {
+                    "version": "0.7.0",
+                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+                    "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+                    "dev": true
+                },
+                "aws4": {
+                    "version": "1.8.0",
+                    "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+                    "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+                    "dev": true
+                },
+                "extend": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+                    "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+                    "dev": true
+                },
+                "fast-deep-equal": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+                    "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+                    "dev": true
+                },
+                "form-data": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+                    "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+                    "dev": true,
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.6",
+                        "mime-types": "^2.1.12"
+                    }
+                },
+                "har-schema": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+                    "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+                    "dev": true
+                },
+                "har-validator": {
+                    "version": "5.1.3",
+                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+                    "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^6.5.5",
+                        "har-schema": "^2.0.0"
+                    }
+                },
+                "http-signature": {
                     "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+                    "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "^1.0.0",
+                        "jsprim": "^1.2.2",
+                        "sshpk": "^1.7.0"
+                    }
+                },
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+                    "dev": true
+                },
+                "mime-db": {
+                    "version": "1.40.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+                    "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+                    "dev": true
+                },
+                "mime-types": {
+                    "version": "2.1.24",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+                    "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+                    "dev": true,
+                    "requires": {
+                        "mime-db": "1.40.0"
+                    }
+                },
+                "oauth-sign": {
+                    "version": "0.9.0",
+                    "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+                    "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+                    "dev": true
+                },
+                "performance-now": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+                    "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+                    "dev": true
+                },
+                "qs": {
+                    "version": "6.5.2",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+                    "dev": true
+                },
+                "request": {
+                    "version": "2.88.0",
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+                    "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+                    "dev": true,
+                    "requires": {
+                        "aws-sign2": "~0.7.0",
+                        "aws4": "^1.8.0",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.6",
+                        "extend": "~3.0.2",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.3.2",
+                        "har-validator": "~5.1.0",
+                        "http-signature": "~1.2.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.19",
+                        "oauth-sign": "~0.9.0",
+                        "performance-now": "^2.1.0",
+                        "qs": "~6.5.2",
+                        "safe-buffer": "^5.1.2",
+                        "tough-cookie": "~2.4.3",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.3.2"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+                    "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+                    "dev": true
+                },
+                "tough-cookie": {
+                    "version": "2.4.3",
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+                    "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+                    "dev": true,
+                    "requires": {
+                        "psl": "^1.1.24",
+                        "punycode": "^1.4.1"
+                    }
+                },
+                "uuid": {
+                    "version": "3.3.3",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+                    "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
                     "dev": true
                 },
                 "webdriver-manager": {
-                    "version": "12.0.6",
-                    "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-12.0.6.tgz",
-                    "integrity": "sha1-PfGkgZdwELTL+MnYXHpXeCjA5ws=",
+                    "version": "12.1.7",
+                    "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-12.1.7.tgz",
+                    "integrity": "sha512-XINj6b8CYuUYC93SG3xPkxlyUc3IJbD6Vvo75CVGuG9uzsefDzWQrhz0Lq8vbPxtb4d63CZdYophF8k8Or/YiA==",
                     "dev": true,
                     "requires": {
-                        "adm-zip": "^0.4.7",
+                        "adm-zip": "^0.4.9",
                         "chalk": "^1.1.1",
                         "del": "^2.2.0",
                         "glob": "^7.0.3",
                         "ini": "^1.3.4",
                         "minimist": "^1.2.0",
                         "q": "^1.4.1",
-                        "request": "^2.78.0",
+                        "request": "^2.87.0",
                         "rimraf": "^2.5.2",
                         "semver": "^5.3.0",
                         "xml2js": "^0.4.17"
@@ -8109,6 +8500,7 @@
             "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
             "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "aws-sign2": "~0.6.0",
                 "aws4": "^1.2.1",
@@ -8138,7 +8530,8 @@
                     "version": "6.4.0",
                     "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
                     "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -8655,6 +9048,7 @@
             "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
             "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "hoek": "2.x.x"
             }
@@ -9104,6 +9498,26 @@
                 }
             }
         },
+        "string.prototype.trimleft": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+            "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "function-bind": "^1.1.1"
+            }
+        },
+        "string.prototype.trimright": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+            "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "function-bind": "^1.1.1"
+            }
+        },
         "string_decoder": {
             "version": "0.10.31",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -9114,7 +9528,8 @@
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
             "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "strip-ansi": {
             "version": "3.0.1",
@@ -9383,6 +9798,7 @@
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
             "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "punycode": "^1.4.1"
             }
@@ -9874,6 +10290,16 @@
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
             "dev": true
         },
+        "util.promisify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+            "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "object.getownpropertydescriptors": "^2.0.3"
+            }
+        },
         "utila": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
@@ -9890,7 +10316,8 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
             "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "v8flags": {
             "version": "3.0.1",
@@ -10231,202 +10658,6 @@
                 }
             }
         },
-        "webdriver-manager": {
-            "version": "12.1.7",
-            "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-12.1.7.tgz",
-            "integrity": "sha512-XINj6b8CYuUYC93SG3xPkxlyUc3IJbD6Vvo75CVGuG9uzsefDzWQrhz0Lq8vbPxtb4d63CZdYophF8k8Or/YiA==",
-            "dev": true,
-            "requires": {
-                "adm-zip": "^0.4.9",
-                "chalk": "^1.1.1",
-                "del": "^2.2.0",
-                "glob": "^7.0.3",
-                "ini": "^1.3.4",
-                "minimist": "^1.2.0",
-                "q": "^1.4.1",
-                "request": "^2.87.0",
-                "rimraf": "^2.5.2",
-                "semver": "^5.3.0",
-                "xml2js": "^0.4.17"
-            },
-            "dependencies": {
-                "adm-zip": {
-                    "version": "0.4.13",
-                    "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
-                    "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw==",
-                    "dev": true
-                },
-                "ajv": {
-                    "version": "6.10.2",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-                    "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
-                    "dev": true,
-                    "requires": {
-                        "fast-deep-equal": "^2.0.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.4.1",
-                        "uri-js": "^4.2.2"
-                    }
-                },
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                    "dev": true
-                },
-                "aws-sign2": {
-                    "version": "0.7.0",
-                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-                    "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-                    "dev": true
-                },
-                "aws4": {
-                    "version": "1.8.0",
-                    "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-                    "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
-                    "dev": true
-                },
-                "extend": {
-                    "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-                    "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-                    "dev": true
-                },
-                "fast-deep-equal": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-                    "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-                    "dev": true
-                },
-                "form-data": {
-                    "version": "2.3.3",
-                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-                    "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-                    "dev": true,
-                    "requires": {
-                        "asynckit": "^0.4.0",
-                        "combined-stream": "^1.0.6",
-                        "mime-types": "^2.1.12"
-                    }
-                },
-                "har-schema": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-                    "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-                    "dev": true
-                },
-                "har-validator": {
-                    "version": "5.1.3",
-                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-                    "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-                    "dev": true,
-                    "requires": {
-                        "ajv": "^6.5.5",
-                        "har-schema": "^2.0.0"
-                    }
-                },
-                "http-signature": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-                    "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-                    "dev": true,
-                    "requires": {
-                        "assert-plus": "^1.0.0",
-                        "jsprim": "^1.2.2",
-                        "sshpk": "^1.7.0"
-                    }
-                },
-                "json-schema-traverse": {
-                    "version": "0.4.1",
-                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-                    "dev": true
-                },
-                "mime-db": {
-                    "version": "1.40.0",
-                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-                    "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
-                    "dev": true
-                },
-                "mime-types": {
-                    "version": "2.1.24",
-                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-                    "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
-                    "dev": true,
-                    "requires": {
-                        "mime-db": "1.40.0"
-                    }
-                },
-                "oauth-sign": {
-                    "version": "0.9.0",
-                    "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-                    "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-                    "dev": true
-                },
-                "performance-now": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-                    "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-                    "dev": true
-                },
-                "qs": {
-                    "version": "6.5.2",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-                    "dev": true
-                },
-                "request": {
-                    "version": "2.88.0",
-                    "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-                    "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-                    "dev": true,
-                    "requires": {
-                        "aws-sign2": "~0.7.0",
-                        "aws4": "^1.8.0",
-                        "caseless": "~0.12.0",
-                        "combined-stream": "~1.0.6",
-                        "extend": "~3.0.2",
-                        "forever-agent": "~0.6.1",
-                        "form-data": "~2.3.2",
-                        "har-validator": "~5.1.0",
-                        "http-signature": "~1.2.0",
-                        "is-typedarray": "~1.0.0",
-                        "isstream": "~0.1.2",
-                        "json-stringify-safe": "~5.0.1",
-                        "mime-types": "~2.1.19",
-                        "oauth-sign": "~0.9.0",
-                        "performance-now": "^2.1.0",
-                        "qs": "~6.5.2",
-                        "safe-buffer": "^5.1.2",
-                        "tough-cookie": "~2.4.3",
-                        "tunnel-agent": "^0.6.0",
-                        "uuid": "^3.3.2"
-                    }
-                },
-                "safe-buffer": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-                    "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
-                    "dev": true
-                },
-                "tough-cookie": {
-                    "version": "2.4.3",
-                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-                    "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-                    "dev": true,
-                    "requires": {
-                        "psl": "^1.1.24",
-                        "punycode": "^1.4.1"
-                    }
-                },
-                "uuid": {
-                    "version": "3.3.3",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-                    "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
-                    "dev": true
-                }
-            }
-        },
         "webpack": {
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-2.5.0.tgz",
@@ -10740,19 +10971,20 @@
             "dev": true
         },
         "xml2js": {
-            "version": "0.4.19",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-            "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+            "version": "0.4.22",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.22.tgz",
+            "integrity": "sha512-MWTbxAQqclRSTnehWWe5nMKzI3VmJ8ltiJEco8akcC6j3miOhjjfzKum5sId+CWhfxdOs/1xauYr8/ZDBtQiRw==",
             "dev": true,
             "requires": {
                 "sax": ">=0.6.0",
-                "xmlbuilder": "~9.0.1"
+                "util.promisify": "~1.0.0",
+                "xmlbuilder": "~11.0.0"
             },
             "dependencies": {
                 "xmlbuilder": {
-                    "version": "9.0.7",
-                    "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-                    "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+                    "version": "11.0.1",
+                    "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+                    "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
                     "dev": true
                 }
             }

--- a/scenarioo-client/package.json
+++ b/scenarioo-client/package.json
@@ -115,7 +115,8 @@
         "wait-on": "^3.1.0",
         "webpack": "2.5.0",
         "webpack-dev-server": "2.4.5",
-        "webpack-merge": "4.1.0"
+        "webpack-merge": "4.1.0",
+        "webdriver-manager": "12.1.7"
     },
     "engines": {
         "node": ">=8.0.0"

--- a/scenarioo-client/package.json
+++ b/scenarioo-client/package.json
@@ -74,6 +74,9 @@
         "typescript": "3.1.6",
         "zone.js": "~0.8.26"
     },
+    "peerDependencies": {
+        "webdriver-manager": "12.1.7"
+    },
     "devDependencies": {
         "@types/angular": "1.6.39",
         "@types/angular-mocks": "1.5.11",
@@ -115,8 +118,7 @@
         "wait-on": "^3.1.0",
         "webpack": "2.5.0",
         "webpack-dev-server": "2.4.5",
-        "webpack-merge": "4.1.0",
-        "webdriver-manager": "12.1.7"
+        "webpack-merge": "4.1.0"
     },
     "engines": {
         "node": ">=8.0.0"


### PR DESCRIPTION
Set explicit version of webdriver-manager in package.json to ensure that the newest version is used, which supports Chrome 76+. (Protractor has version 12.0.6 as dependency)