### PR TITLE
#953: Additional fix in case of encoded percentage sign

### DIFF
--- a/scenarioo-client/test/e2e/specs/step_view.ts
+++ b/scenarioo-client/test/e2e/specs/step_view.ts
@@ -160,7 +160,7 @@ useCase('Step - View')
         scenario('Step with encoded space in url')
             .description('A step where the step has an encoded space in the url should be found')
             .it(async () => {
-                await Utils.navigateToRoute('/step/Technical Corner Cases/dummy_scenario_with_one_step_with_an_encoded_space_in_url/url-with-encoded%2520space.jsp/0/0');
+                await Utils.navigateToRoute('/step/Technical Corner Cases/dummy_scenario_with_one_step_with_an_encoded_space_in_url/url-with%252520encoded%2520space.jsp/0/0');
                 await StepPage.assertScreenshotIsShown();
                 await step('A step with an encoded space in the path can be found');
             });

--- a/scenarioo-docu-generation-example/src/test/java/org/scenarioo/uitest/dummy/application/steps/DummyApplicationStepDataFactory.java
+++ b/scenarioo-docu-generation-example/src/test/java/org/scenarioo/uitest/dummy/application/steps/DummyApplicationStepDataFactory.java
@@ -160,8 +160,8 @@ public class DummyApplicationStepDataFactory {
 		createStep("urlWithParenthesesAndSpace");
 
 		// create TECHNICAL_PARENTHESES_STEP_CONFIG
-		startConfig(TECHNICAL_ENCODED_SPACE_STEP_CONFIG).startUrl("http://www.wikipedia.org/url-with-encoded%20space");
-		title("Technical Page with Encoded Space").pageName("url-with-encoded%20space.jsp").callTreeStart();
+		startConfig(TECHNICAL_ENCODED_SPACE_STEP_CONFIG).startUrl("http://www.wikipedia.org/url-with%2520encoded%20space");
+		title("Technical Page with Encoded Space").pageName("url-with%2520encoded%20space.jsp").callTreeStart();
 		createStep("urlWithEncodedSpace");
 
 		return steps;

--- a/scenarioo-docu-generation-example/src/test/java/org/scenarioo/uitest/example/testcases/TechnicalCornerCasesUITest.java
+++ b/scenarioo-docu-generation-example/src/test/java/org/scenarioo/uitest/example/testcases/TechnicalCornerCasesUITest.java
@@ -99,7 +99,7 @@ public class TechnicalCornerCasesUITest extends UITest {
 	@Labels({ "encoding" })
 	public void dummy_scenario_with_one_step_with_an_encoded_space_in_url() {
 		DummyApplicationSimulator.setConfiguration(DummySimulationConfig.TECHNICAL_ENCODED_SPACE_STEP_CONFIG);
-		toolkit.loadUrl("http://www.wikipedia.org/url-with-encoded%20space");
+		toolkit.loadUrl("http://www.wikipedia.org/url-with%2520encoded%20space");
 	}
 
 

--- a/scenarioo-server/src/main/java/org/scenarioo/rest/step/logic/StepIndexResolver.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/rest/step/logic/StepIndexResolver.java
@@ -16,7 +16,9 @@ public class StepIndexResolver {
 	private static final Logger LOGGER = Logger.getLogger(StepIndexResolver.class);
 
 	private static final String ENCODED_SPACE = "%20";
+	private static final String ENCODED_PERCENT = "%25";
 	private static final String SPACE = " ";
+	private static final String PERCENT = "%";
 
 	/**
 	 * Retrieves the overall index of a step in the scenario given a step identifier. Can do a fallback in case the
@@ -103,9 +105,21 @@ public class StepIndexResolver {
 		// Spring Boot automatically decodes all encoded spaces.
 		// As a consequence we may not be able to find a file that contains an encoded space.
 		// If we did not find a direct match we try again with all encoded spaces removed.
-		String sanitizedPageName = pageName.replaceAll(ENCODED_SPACE, SPACE);
-		String sanitizedPageWithStepsPageName =  pageWithSteps.getPage().getName().replaceAll(ENCODED_SPACE, SPACE);
+		String sanitizedPageName = sanitizePageName(pageName);
+		String sanitizedPageWithStepsPageName = sanitizePageName(pageWithSteps.getPage().getName());
 		return sanitizedPageName.equals(sanitizedPageWithStepsPageName);
+	}
+
+	/**
+	 * A space is encoded with %20, this in turn is encoded as %2520 and every time it is further encoded
+	 * another 25 is added, thus we have to replace %25 with % for as long as it is still present in the String,
+	 * only then can we replace %20 with a space.
+	 */
+	private String sanitizePageName(String pageName) {
+		while(pageName.contains(ENCODED_PERCENT)) {
+			pageName = pageName.replaceAll(ENCODED_PERCENT, PERCENT);
+		}
+		return pageName.replaceAll(ENCODED_SPACE, SPACE);
 	}
 
 	private ResolveStepIndexResult findBestStepInEntireScenario(final StepIdentifier stepIdentifier,

--- a/scenarioo-server/src/test/java/org/scenarioo/rest/step/logic/StepIndexResolverTest.java
+++ b/scenarioo-server/src/test/java/org/scenarioo/rest/step/logic/StepIndexResolverTest.java
@@ -57,6 +57,26 @@ class StepIndexResolverTest {
 	}
 
 	@Test
+	void resolveIndexSuccessful_whenSpaceEncodingIsDoublyEncoded_stepEncoded() {
+		givenStepIdentifierWithSpaceOfAnExistingStepWithDoublyEncodedSpace();
+
+		whenResolvingTheStepIndex();
+
+		expectRequestedStepIndexIsFound();
+	}
+
+	@Test
+	void resolveIndexSuccessful_whenPercentageIsDoublyEncoded_stepEncoded() {
+		givenStepIdentifierWithSpaceOfAnExistingStepWithDoublyEncodedPercentageAndSpace();
+
+		whenResolvingTheStepIndex();
+
+		expectRequestedStepIndexIsFound();
+	}
+
+	//step_Technical Corner Cases_dummy_scenario_with_one_step_with_an_encoded_space_in_url_url-with-encoded%2520space.jsp_0_0
+
+	@Test
 	void stepInPageOccurrenceNotFound_fallbackWithinSamePageOccurrence() {
 		givenStepIdentifierWhereStepInPageOccurrenceDoesNotExist();
 
@@ -124,6 +144,18 @@ class StepIndexResolverTest {
 		stepIdentifier = new StepIdentifier(USECASE_IDENTIFIER, StepTestData.PAGE_NAME_VALID_1+" Test", 1, 2);
 		scenarioPagesAndSteps = StepTestData.createScenarioPagesAndSteps();
 		scenarioPagesAndSteps.getPagesAndSteps().forEach(pageAndSteps -> pageAndSteps.getPage().setName(pageAndSteps.getPage().getName()+"%20Test"));
+	}
+
+	private void givenStepIdentifierWithSpaceOfAnExistingStepWithDoublyEncodedSpace() {
+		stepIdentifier = new StepIdentifier(USECASE_IDENTIFIER, StepTestData.PAGE_NAME_VALID_1 + " Test", 1, 2);
+		scenarioPagesAndSteps = StepTestData.createScenarioPagesAndSteps();
+		scenarioPagesAndSteps.getPagesAndSteps().forEach(pageAndSteps -> pageAndSteps.getPage().setName(pageAndSteps.getPage().getName() + "%2520Test"));
+	}
+
+	private void givenStepIdentifierWithSpaceOfAnExistingStepWithDoublyEncodedPercentageAndSpace() {
+		stepIdentifier = new StepIdentifier(USECASE_IDENTIFIER, StepTestData.PAGE_NAME_VALID_1 + " Test", 1, 2);
+		scenarioPagesAndSteps = StepTestData.createScenarioPagesAndSteps();
+		scenarioPagesAndSteps.getPagesAndSteps().forEach(pageAndSteps -> pageAndSteps.getPage().setName(pageAndSteps.getPage().getName() + "%252520Test"));
 	}
 
 	private void givenStepIdentifierWithEncodedSpaceOfAnExistingStepWithSpace() {


### PR DESCRIPTION
The generated scenario from our E2E Test which verified that a page with an encoded space (%20) could be accessed, could not be accessed because the percentage was also encoded (%2520).

See this [page](http://demo.scenarioo.org/scenarioo-release-5.0/#/step/Step%20-%20View/Step%20with%20encoded%20space%20in%20url/step_Technical%2520Corner%2520Cases_dummy_scenario_with_one_step_with_an_encoded_space_in_url_url-with-encoded%252520space.jsp_0_0/0/0?branch=scenarioo-release-5.0&build=last%20successful&comparison=Disabled) in our hotfix release candidate self docu.

To replicate this I extended the test case to also include an encoded percentage.

To solve this problem I added additional logic to replace all encoded percentage signs before replacing the encoded space.

Here is a [link](http://demo.scenarioo.org/scenarioo-feature-953-correctly-handle-parentheses/#/step/Step%20-%20View/Step%20with%20encoded%20space%20in%20url/step_Technical%2520Corner%2520Cases_dummy_scenario_with_one_step_with_an_encoded_space_in_url_url-with%25252520encoded%252520space.jsp_0_0/0/0?branch=scenarioo-feature-953-correctly-handle-parentheses&build=last%20successful&comparison=Disabled) to the demo where the page works.