### PR TITLE
Detailarea Improvements / Cleanup

### DIFF
--- a/scenarioo-client/app/build/mainpage/share/share.component.css
+++ b/scenarioo-client/app/build/mainpage/share/share.component.css
@@ -11,8 +11,8 @@
 }
 
 #shareButton {
-    border: unset;
-    background-color: unset;
-    padding: unset;
+    border: none;
+    background-color: transparent;
+    padding: 0;
     color: #337ab7;
 }

--- a/scenarioo-client/app/components/detailarea/detail-accordion/detail-accordion.component.css
+++ b/scenarioo-client/app/components/detailarea/detail-accordion/detail-accordion.component.css
@@ -17,8 +17,8 @@ accordion {
 
 .panel-group .panel {
     margin-bottom: 10px;
-    background-color: unset;
-    box-shadow: unset;
+    background-color: transparent;
+    box-shadow: none;
 }
 
 .panel-group .panel-heading {

--- a/scenarioo-client/app/components/detailarea/detailarea.component.css
+++ b/scenarioo-client/app/components/detailarea/detailarea.component.css
@@ -1,5 +1,10 @@
-/* Buttons over detailarea */
+/* Details Area Container (top level div) */
+sc-detailarea .details-area-container {
+    margin-top: 35px;
+    height: 100%;
+}
 
+/* Buttons over detailarea (to hide / expand the details area) */
 sc-detailarea button.btn.btn-primary {
     background-color: unset;
     border: unset;
@@ -20,42 +25,57 @@ sc-detailarea button.btn.btn-primary:active {
     color: #333333;
 }
 
+/* General flex box layout styles */
 
-/* Detailarea */
-
-sc-detailarea .sc-meta-data-panel {
-    margin-top: 35px;
+sc-detailarea .flex {
+    display: flex;
 }
 
-sc-detailarea .detail-container {
+sc-detailarea .flex-fill {
+    flex: 1 1 auto;
+}
+
+/* Colapsable Details Panel */
+
+sc-detailarea .details-panel {
     border: 1px solid #ccc;
     border-right: 0;
-    display: table;
     padding: unset;
     background-color: #eeeeee;
-    right: 0;
 }
 
-sc-detailarea .detail-row {
-    display: table-row;
-}
-
-sc-detailarea .detail-cell {
-    display: table-cell;
-}
-
-sc-detailarea .detail-button {
+sc-detailarea .details-collapse-button {
     background-color: #CCCCCC;
     width: 30px;
+    min-width: 30px; /* do never shrink */
     font-size: x-large;
     color: #337AB7;
     cursor: pointer;
 }
 
+sc-detailarea .sticky-arrow-container {
+    display: block;
+    vertical-align: top;
+    top: 0;
+    height: 100%;
+}
+
+sc-detailarea .sticky-arrow-icon-area {
+    position: -webkit-sticky;
+    position: sticky;
+    top: 33vh; /* 2 times this plus the height should add to 100vh => sticky arrow is centered once full container is scrolled into view */
+    height: 34vh;
+    /* reasons for choosen height - it seems a good compromise between:
+     * 100vh = having to scroll too far down on small screens until you see the arrow
+     * 5vh = having the arrow too near to the top of the details panel until full panel scrolled into view
+     */
+    vertical-align: middle;
+}
+
 sc-detailarea .arrowCenter {
-    position: fixed;
+    position: relative;
     margin-left: 10px;
-    top: 55%;
+    height: 100%;
 }
 
 sc-detailarea .detail-section {

--- a/scenarioo-client/app/components/detailarea/detailarea.component.css
+++ b/scenarioo-client/app/components/detailarea/detailarea.component.css
@@ -6,8 +6,8 @@ sc-detailarea .details-area-container {
 
 /* Buttons over detailarea (to hide / expand the details area) */
 sc-detailarea button.btn.btn-primary {
-    background-color: unset;
-    border: unset;
+    background-color: transparent;
+    border: none;
     color: #337AB7;
     font-style: italic;
     padding: 0;
@@ -16,9 +16,8 @@ sc-detailarea button.btn.btn-primary {
 }
 
 sc-detailarea button.btn.btn-primary:focus {
-    outline: unset;
     background-color: transparent;
-    box-shadow: unset;
+    box-shadow: none;
 }
 
 sc-detailarea button.btn.btn-primary:active {

--- a/scenarioo-client/app/components/detailarea/detailarea.component.css
+++ b/scenarioo-client/app/components/detailarea/detailarea.component.css
@@ -40,7 +40,7 @@ sc-detailarea .flex-fill {
 sc-detailarea .details-panel {
     border: 1px solid #ccc;
     border-right: 0;
-    padding: unset;
+    padding: 0;
     background-color: #eeeeee;
 }
 
@@ -54,28 +54,21 @@ sc-detailarea .details-collapse-button {
 }
 
 sc-detailarea .sticky-arrow-container {
-    display: block;
-    vertical-align: top;
-    top: 0;
     height: 100%;
 }
 
 sc-detailarea .sticky-arrow-icon-area {
     position: -webkit-sticky;
     position: sticky;
-    top: 33vh; /* 2 times this plus the height should add to 100vh => sticky arrow is centered once full container is scrolled into view */
-    height: 34vh;
+    top: 10vh; /* 2 times this plus the height should add to 100vh => sticky arrow is centered once full container is scrolled into view */
+    height: 80vh;
     /* reasons for choosen height - it seems a good compromise between:
      * 100vh = having to scroll too far down on small screens until you see the arrow
-     * 5vh = having the arrow too near to the top of the details panel until full panel scrolled into view
+     * 50vh = having the arrow too near to the top of the details panel (as long as not yet scrolled down)
      */
-    vertical-align: middle;
-}
-
-sc-detailarea .arrowCenter {
-    position: relative;
-    margin-left: 10px;
-    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-around;
 }
 
 sc-detailarea .detail-section {

--- a/scenarioo-client/app/components/detailarea/detailarea.component.css
+++ b/scenarioo-client/app/components/detailarea/detailarea.component.css
@@ -1,30 +1,21 @@
 /* Details Area Container (top level div) */
 sc-detailarea .details-area-container {
-    margin-top: 35px;
+    margin-top: 2px;
     height: 100%;
 }
 
-/* Buttons over detailarea (to hide / expand the details area) */
-sc-detailarea button.btn.btn-primary {
-    background-color: transparent;
-    border: none;
-    color: #337AB7;
-    font-style: italic;
-    padding: 0;
+/* Link to Hide/Show Details (top right) */
+
+sc-detailarea #sc-showHideDetailsButton {
     margin-right: 15px;
-    margin-top: -25px;
+    padding: 2px 0 2px 0;
 }
 
-sc-detailarea button.btn.btn-primary:focus {
-    background-color: transparent;
-    box-shadow: none;
+sc-detailarea a#sc-showHideDetailsButton:hover {
+    text-decoration: none
 }
 
-sc-detailarea button.btn.btn-primary:active {
-    color: #333333;
-}
-
-/* General flex box layout styles */
+/* General flex box layout styles (because we not have bootstrap 4 yet) */
 
 sc-detailarea .flex {
     display: flex;
@@ -78,7 +69,7 @@ sc-detailarea .detail-section {
 
 sc-detailarea .detail-section h3 {
     font-weight: bold;
-    margin-top: 30px;
-    margin-bottom: 20px;
+    margin-top: 20px;
+    margin-bottom: 15px;
     margin-left: 10px;
 }

--- a/scenarioo-client/app/components/detailarea/detailarea.component.html
+++ b/scenarioo-client/app/components/detailarea/detailarea.component.html
@@ -15,41 +15,83 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<div class="sc-meta-data-panel row">
+<div class="details-area-container">
 
-    <button (click)="togglePannelCollapsedValue()" [attr.aria-expanded]="!isPanelCollapsed" aria-controls="collapseBasic"
-            class="btn btn-primary pull-right" id="sc-showHideDetailsButton" type="button">
-        {{ isPanelCollapsed ? "Show details" : "Hide details" }}
-    </button>
-
-    <div [ngClass]="isPanelCollapsed ? 'col-sm-11' : 'col-sm-8'">
-        <ng-content></ng-content>
+    <!-- Top Level Button Row -->
+    <div class="row">
+        <button (click)="togglePannelCollapsedValue()" [attr.aria-expanded]="!isPanelCollapsed" aria-controls="collapseBasic"
+                class="btn btn-primary pull-right" id="sc-showHideDetailsButton" type="button">
+            {{ isPanelCollapsed ? "Show details" : "Hide details" }}
+        </button>
     </div>
 
-    <div #metaDataPanel class="detail-container pull-right"  [ngClass]="isPanelCollapsed ? '' : 'col-sm-4'">
-        <div class="detail-row">
-            <div (click)="togglePannelCollapsedValue()" class="detail-cell detail-button">
-                <span *ngIf="!isPanelCollapsed">
-                    <i class="fas arrowCenter fa-angle-right"></i>
-                </span>
-                <span *ngIf="isPanelCollapsed">
-                    <i class="fas arrowCenter fa-angle-left"></i>
-                </span>
-            </div>
+    <!-- Content Area -->
+    <div class="row flex">
 
-            <div [collapse]="isPanelCollapsed" id="sc-metadata-panel">
-                <div class="detail-cell detail-section">
-                    <h3>Details</h3>
-                    <accordion>
 
-                    <ng-container  *ngFor="let mainDetailsSection of mainDetailsSections" >
-                        <sc-detail-accordion *ngIf="(mainDetailsSection.dataTree && !isEmptyObject(mainDetailsSection.dataTree)) || (mainDetailsSection.values && !isEmptyObject(mainDetailsSection.values))" [dataTree]="mainDetailsSection.dataTree" [values]="mainDetailsSection.values" [labelConfigurations]="mainDetailsSection.labelConfigurations" [detailAccordionName]="mainDetailsSection.name" key="{{key}}-{{mainDetailsSection.key}}" [isFirstOpen]="mainDetailsSection.isFirstOpen" [detailSectionType]="mainDetailsSection.detailSectionType"></sc-detail-accordion>
-                    </ng-container>
-
-                    <sc-detail-accordion *ngFor="let additionalDetailsSection of additionalDetailsSections | keyvalue" [dataTree]="additionalDetailsSection.value" [detailAccordionName]="additionalDetailsSection.key" key="{{key}}-{{additionalDetailsSection.key}}" [isFirstOpen]="false" detailSectionType="treeComponent"></sc-detail-accordion>
-
-                </accordion>
-            </div>
+        <!-- Page Content left (will fill if details are collapsed) -->
+        <div class="detailarea-page-content"
+             [ngClass]="isPanelCollapsed ? 'col-sm-11 flex-fill' : 'col-sm-8'">
+            <ng-content></ng-content>
         </div>
+
+        <!-- Details Panel right -->
+        <div #detailsPanel
+             class="details-panel flex"
+             [ngClass]="isPanelCollapsed ? '' : 'col-sm-4'">
+
+            <div class="flex-fill flex">
+
+                <!-- Button to collapse or expand -->
+                <div (click)="togglePannelCollapsedValue()" class="details-collapse-button">
+
+                    <div class="sticky-arrow-container">
+                        <!-- the sticky arrow needs a parent container that is not otherwise styled (just a simple block to take the full available height!) -->
+                        <div class="sticky-arrow-icon-area" *ngIf="!isPanelCollapsed">
+                            <i class="fas arrowCenter fa-angle-right"></i>
+                        </div>
+                        <div class="sticky-arrow-icon-area" *ngIf="isPanelCollapsed">
+                            <i class="fas arrowCenter fa-angle-left"></i>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Details Content (collapsable) -->
+                <div [collapse]="isPanelCollapsed" class="details-content flex-fill">
+
+                    <div class="detail-section">
+                        <h3>Details</h3>
+                        <accordion>
+
+                            <ng-container *ngFor="let mainDetailsSection of mainDetailsSections" >
+                                <sc-detail-accordion
+                                    *ngIf="(mainDetailsSection.dataTree && !isEmptyObject(mainDetailsSection.dataTree)) || (mainDetailsSection.values && !isEmptyObject(mainDetailsSection.values))"
+                                    [dataTree]="mainDetailsSection.dataTree"
+                                    [values]="mainDetailsSection.values"
+                                    [detailAccordionName]="mainDetailsSection.name"
+                                    key="{{key}}-{{mainDetailsSection.key}}" [isFirstOpen]="mainDetailsSection.isFirstOpen"
+                                    [detailSectionType]="mainDetailsSection.detailSectionType">
+                                </sc-detail-accordion>
+                            </ng-container>
+
+                            <sc-detail-accordion
+                                *ngFor="let additionalDetailsSection of additionalDetailsSections | keyvalue"
+                                [dataTree]="additionalDetailsSection.value"
+                                [detailAccordionName]="additionalDetailsSection.key"
+                                key="{{key}}-{{additionalDetailsSection.key}}"
+                                [isFirstOpen]="false"
+                                detailSectionType="treeComponent">
+                            </sc-detail-accordion>
+
+                        </accordion>
+
+                    </div>
+
+                </div>
+            </div>
+
+        </div>
+
     </div>
+
 </div>

--- a/scenarioo-client/app/components/detailarea/detailarea.component.html
+++ b/scenarioo-client/app/components/detailarea/detailarea.component.html
@@ -48,10 +48,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     <div class="sticky-arrow-container">
                         <!-- the sticky arrow needs a parent container that is not otherwise styled (just a simple block to take the full available height!) -->
                         <div class="sticky-arrow-icon-area" *ngIf="!isPanelCollapsed">
-                            <i class="fas arrowCenter fa-angle-right"></i>
+                            <i class="fas fa-angle-right"></i>
                         </div>
                         <div class="sticky-arrow-icon-area" *ngIf="isPanelCollapsed">
-                            <i class="fas arrowCenter fa-angle-left"></i>
+                            <i class="fas fa-angle-left"></i>
                         </div>
                     </div>
                 </div>

--- a/scenarioo-client/app/components/detailarea/detailarea.component.html
+++ b/scenarioo-client/app/components/detailarea/detailarea.component.html
@@ -19,10 +19,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     <!-- Top Level Button Row -->
     <div class="row">
-        <button (click)="togglePannelCollapsedValue()" [attr.aria-expanded]="!isPanelCollapsed" aria-controls="collapseBasic"
-                class="btn btn-primary pull-right" id="sc-showHideDetailsButton" type="button">
-            {{ isPanelCollapsed ? "Show details" : "Hide details" }}
-        </button>
+        <a id="sc-showHideDetailsButton"
+            role="button"
+            class="btn btn-link pull-right"
+            (click)="togglePannelCollapsedValue()"
+            [attr.aria-expanded]="!isPanelCollapsed"
+            aria-controls="collapseBasic"
+            >
+            {{ isPanelCollapsed ? "Show Details" : "Hide Details" }}
+        </a>
     </div>
 
     <!-- Content Area -->

--- a/scenarioo-client/app/components/detailarea/detailarea.component.ts
+++ b/scenarioo-client/app/components/detailarea/detailarea.component.ts
@@ -74,7 +74,8 @@ export class DetailareaComponent {
         const detailsPanel = this.detailsPanel.nativeElement;
         const headerHeight = detailsPanel.offsetTop;
 
-        // let the details area expand to minimum of rest of visible area! (but still keep its height to 100% for larger pages!)
+        // let the details area expand to minimum of rest of visible area!
+        // (but still let it expand to full page size if it is even higher)
         detailsPanel.style.minHeight = 'calc(100vh - ' + headerHeight + 'px)';
     }
 

--- a/scenarioo-client/app/components/detailarea/detailarea.component.ts
+++ b/scenarioo-client/app/components/detailarea/detailarea.component.ts
@@ -15,12 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {Component, ElementRef, EventEmitter, HostListener, Input, Output, ViewChild} from '@angular/core';
+import {Component, ElementRef, HostListener, Input, ViewChild} from '@angular/core';
 import {LocalStorageService} from '../../services/localStorage.service';
 import {IMainDetailsSection} from './IMainDetailsSection';
 import {IDetailsSections} from './IDetailsSections';
-import {ICustomObjectTabTree, ILabelConfiguration} from '../../generated-types/backend-types';
-import {RelatedIssueSummary} from '../../shared/services/relatedIssueResource.service';
 
 const LOCALSTORAGE_KEY_PREFIX_DETAILS_VISIBLE = 'scenarioo-metadataVisible-';
 
@@ -47,8 +45,11 @@ export class DetailareaComponent {
     @Input()
     additionalDetailsSections: IDetailsSections;
 
-    @ViewChild('metaDataPanel')
-    metaDataPanel: ElementRef;
+    /**
+     * The element of the collapsable details panel (that can be opened and closed).
+     */
+    @ViewChild('detailsPanel')
+    detailsPanel: ElementRef;
 
     isPanelCollapsed: boolean = true;
 
@@ -70,9 +71,11 @@ export class DetailareaComponent {
     }
 
     private setHeightOfDetailarea() {
-        const metaDataPanel = this.metaDataPanel.nativeElement;
-        const headerHeight = metaDataPanel.offsetTop;
-        metaDataPanel.style.height = 'calc(100vh - ' + headerHeight + 'px)';
+        const detailsPanel = this.detailsPanel.nativeElement;
+        const headerHeight = detailsPanel.offsetTop;
+
+        // let the details area expand to minimum of rest of visible area! (but still keep its height to 100% for larger pages!)
+        detailsPanel.style.minHeight = 'calc(100vh - ' + headerHeight + 'px)';
     }
 
     togglePannelCollapsedValue() {

--- a/scenarioo-client/app/components/detailarea/detailarea.component.ts
+++ b/scenarioo-client/app/components/detailarea/detailarea.component.ts
@@ -72,7 +72,7 @@ export class DetailareaComponent {
 
     private setHeightOfDetailarea() {
         const detailsPanel = this.detailsPanel.nativeElement;
-        const headerHeight = detailsPanel.offsetTop;
+        const headerHeight = detailsPanel.offsetTop + 2;
 
         // let the details area expand to minimum of rest of visible area!
         // (but still let it expand to full page size if it is even higher)

--- a/scenarioo-client/app/styles/scenarioo.less
+++ b/scenarioo-client/app/styles/scenarioo.less
@@ -463,9 +463,13 @@ span.sc-screenshot-annotation-with-action {
   margin-bottom: @vertical-space;
 }
 
+
+/* Tabs (reduce taking too much vertical space) */
 .tab-content {
-  /* reduced margins for not taking too much vertical space */
-  margin-top: @vertical-space;
+  margin-top: 0;
+}
+tabset .nav-tabs {
+    margin-bottom: 0;
 }
 
 .panel {

--- a/scenarioo-client/test/e2e/pages/detailAreaPage.ts
+++ b/scenarioo-client/test/e2e/pages/detailAreaPage.ts
@@ -5,7 +5,7 @@ import {by, element} from 'protractor';
 class DetailAreaPage {
 
     private toggleMetaDataButton = element(by.id('sc-showHideDetailsButton'));
-    private detailsPanel = element(by.class('details-content'));
+    private detailsPanel = element(by.css('.details-content'));
 
     async assertDetailsAreaExpanded() {
         await expect(this.toggleMetaDataButton.getText()).toEqual('Hide details');

--- a/scenarioo-client/test/e2e/pages/detailAreaPage.ts
+++ b/scenarioo-client/test/e2e/pages/detailAreaPage.ts
@@ -5,16 +5,16 @@ import {by, element} from 'protractor';
 class DetailAreaPage {
 
     private toggleMetaDataButton = element(by.id('sc-showHideDetailsButton'));
-    private metaDataPanel = element(by.id('sc-metadata-panel'));
+    private detailsPanel = element(by.class('details-content'));
 
     async assertDetailsAreaExpanded() {
         await expect(this.toggleMetaDataButton.getText()).toEqual('Hide details');
-        return expect(this.metaDataPanel.isDisplayed()).toBe(true);
+        return expect(this.detailsPanel.isDisplayed()).toBe(true);
     }
 
     async assertDetailsAreaCollapsed() {
         await expect(this.toggleMetaDataButton.getText()).toEqual('Show details');
-        return expect(this.metaDataPanel.isDisplayed()).toBe(false);
+        return expect(this.detailsPanel.isDisplayed()).toBe(false);
     }
 
     async expandDetailsArea() {

--- a/scenarioo-client/test/e2e/pages/detailAreaPage.ts
+++ b/scenarioo-client/test/e2e/pages/detailAreaPage.ts
@@ -8,12 +8,12 @@ class DetailAreaPage {
     private detailsContentPanel = element(by.css('sc-detailarea .details-content'));
 
     async assertDetailsExpanded() {
-        await expect(this.collapseButton.getText()).toEqual('Hide details');
+        await expect(this.collapseButton.getText()).toEqual('Hide Details');
         return expect(this.detailsContentPanel.isDisplayed()).toBe(true);
     }
 
     async assertDetailsCollapsed() {
-        await expect(this.collapseButton.getText()).toEqual('Show details');
+        await expect(this.collapseButton.getText()).toEqual('Show Details');
         return expect(this.detailsContentPanel.isDisplayed()).toBe(false);
     }
 

--- a/scenarioo-client/test/e2e/pages/detailAreaPage.ts
+++ b/scenarioo-client/test/e2e/pages/detailAreaPage.ts
@@ -4,46 +4,46 @@ import {by, element} from 'protractor';
 
 class DetailAreaPage {
 
-    private toggleMetaDataButton = element(by.id('sc-showHideDetailsButton'));
-    private detailsPanel = element(by.css('.details-content'));
+    private collapseButton = element(by.id('sc-showHideDetailsButton'));
+    private detailsContentPanel = element(by.css('sc-detailarea .details-content'));
 
-    async assertDetailsAreaExpanded() {
-        await expect(this.toggleMetaDataButton.getText()).toEqual('Hide details');
-        return expect(this.detailsPanel.isDisplayed()).toBe(true);
+    async assertDetailsExpanded() {
+        await expect(this.collapseButton.getText()).toEqual('Hide details');
+        return expect(this.detailsContentPanel.isDisplayed()).toBe(true);
     }
 
-    async assertDetailsAreaCollapsed() {
-        await expect(this.toggleMetaDataButton.getText()).toEqual('Show details');
-        return expect(this.detailsPanel.isDisplayed()).toBe(false);
+    async assertDetailsCollapsed() {
+        await expect(this.collapseButton.getText()).toEqual('Show details');
+        return expect(this.detailsContentPanel.isDisplayed()).toBe(false);
     }
 
-    async expandDetailsArea() {
-        return this.toggleMetaDataButton.click();
+    async expandDetails() {
+        return this.collapseButton.click();
     }
 
-    async collapseDetailsArea() {
-        return this.toggleMetaDataButton.click();
+    async collapseDetails() {
+        return this.collapseButton.click();
     }
 
-    async assertSectionExpanded(detailsSection) {
-        const section = element(by.id('sc-section-' + detailsSection));
+    async assertSectionExpanded(sectionName) {
+        const section = element(by.id('sc-section-' + sectionName));
         return expect(section.getAttribute('aria-expanded')).toEqual('true');
     }
 
-    async assertSectionCollapsed(detailsSection) {
-        const section = element(by.id('sc-section-' + detailsSection));
+    async assertSectionCollapsed(sectionName) {
+        const section = element(by.id('sc-section-' + sectionName));
         return expect(section.getAttribute('aria-expanded')).toEqual('false');
     }
 
-    async expandDetailsSection(detailsSection) {
-        await this.assertSectionCollapsed(detailsSection);
-        const toggleSection = element(by.id('sc-toggleSection-' + detailsSection));
+    async expandSection(sectionName) {
+        await this.assertSectionCollapsed(sectionName);
+        const toggleSection = element(by.id('sc-toggleSection-' + sectionName));
         return await toggleSection.click();
     }
 
-    async collapseDetailsSection(detailsSection) {
-        await this.assertSectionExpanded(detailsSection);
-        const toggleSection = element(by.id('sc-toggleSection-' + detailsSection));
+    async collapseSection(sectionName) {
+        await this.assertSectionExpanded(sectionName);
+        const toggleSection = element(by.id('sc-toggleSection-' + sectionName));
         return await toggleSection.click();
     }
 }

--- a/scenarioo-client/test/e2e/pages/homePage.ts
+++ b/scenarioo-client/test/e2e/pages/homePage.ts
@@ -1,7 +1,8 @@
 'use strict';
 
-import { browser, by, element, $ } from 'protractor';
+import {$, browser, by, element} from 'protractor';
 import * as Utils from '../util';
+import detailAreaPage from './detailAreaPage';
 
 class HomePage {
 
@@ -10,8 +11,7 @@ class HomePage {
     private aboutScenariooPopup = $('.modal.about-popup');
     private popupCloseButton = $('.modal-footer button.btn');
     private usecaseTable = $('table.usecase-table');
-    private toggleMetaDataButton = element(by.id('sc-showHideDetailsButton'));
-    private metaDataPanel = element(by.id('sc-metadata-panel'));
+    private detailArea = detailAreaPage;
     private sketchesTab = element(by.id('sc-main-tab-sketches-link'));
     private pagesTab = element(by.id('sc-main-tab-pages-link'));
 
@@ -63,22 +63,20 @@ class HomePage {
         });
     }
 
-    async showMetaData() {
-        return this.toggleMetaDataButton.click();
+    async assertDetailsExpanded() {
+        return this.detailArea.assertDetailsExpanded();
     }
 
-    async assertMetaDataShown() {
-        await expect(this.toggleMetaDataButton.getText()).toEqual('Hide details');
-        return expect(this.metaDataPanel.isDisplayed()).toBe(true);
+    async assertDetailsCollapsed() {
+        return this.detailArea.assertDetailsCollapsed();
     }
 
-    async assertMetaDataHidden() {
-        await expect(this.toggleMetaDataButton.getText()).toEqual('Show details');
-        return expect(this.metaDataPanel.isDisplayed()).toBe(false);
+    async expandDetails() {
+        return this.detailArea.expandDetails();
     }
 
-    async hideMetaData() {
-        return this.toggleMetaDataButton.click();
+    async collapseDetails() {
+        return this.detailArea.collapseDetails();
     }
 
     async sortByChanges() {

--- a/scenarioo-client/test/e2e/specs/browse_detailarea.ts
+++ b/scenarioo-client/test/e2e/specs/browse_detailarea.ts
@@ -5,9 +5,6 @@ import * as Utils from '../util';
 import HomePage from '../pages/homePage';
 import DetailAreaPage from '../pages/detailAreaPage';
 
-// Just to make TypeScript happy
-declare var angular: any;
-
 const SECOND_USE_CASE = 1;
 
 useCase('Browse Detailarea')
@@ -23,32 +20,32 @@ useCase('Browse Detailarea')
         scenario('Remembers collapsed state of details area and sections on usecases overview')
             .description('States of detailarea and sections are correctly saved in LocalStorage.')
             .it(async () => {
-                await DetailAreaPage.assertDetailsAreaExpanded();
+                await DetailAreaPage.assertDetailsExpanded();
                 await DetailAreaPage.assertSectionExpanded('Build');
                 await DetailAreaPage.assertSectionExpanded('Branch');
                 await step('Detailarea and important sections are expanded on first visit');
 
-                await DetailAreaPage.collapseDetailsSection('Build');
+                await DetailAreaPage.collapseSection('Build');
                 await DetailAreaPage.assertSectionCollapsed('Build');
                 await step('Build section has been collapsed');
 
-                await DetailAreaPage.collapseDetailsArea();
-                await DetailAreaPage.assertDetailsAreaCollapsed();
+                await DetailAreaPage.collapseDetails();
+                await DetailAreaPage.assertDetailsCollapsed();
                 await step('Detailarea has been collapsed');
 
                 await Utils.refreshBrowser();
-                await DetailAreaPage.assertDetailsAreaCollapsed();
+                await DetailAreaPage.assertDetailsCollapsed();
                 await step('Collapsed detailarea is remembered on revisit.');
 
-                await DetailAreaPage.expandDetailsArea();
-                await DetailAreaPage.assertDetailsAreaExpanded();
+                await DetailAreaPage.expandDetails();
+                await DetailAreaPage.assertDetailsExpanded();
                 await step('Detailarea has been expanded');
 
                 await DetailAreaPage.assertSectionExpanded('Branch');
                 await DetailAreaPage.assertSectionCollapsed('Build');
                 await step('Collapsed or expanded areas are remembered on revisit');
 
-                await DetailAreaPage.expandDetailsSection('Build');
+                await DetailAreaPage.expandSection('Build');
                 await DetailAreaPage.assertSectionExpanded('Build');
                 await step('Build section has been expanded');
             });
@@ -59,28 +56,28 @@ useCase('Browse Detailarea')
                 await HomePage.selectUseCase(SECOND_USE_CASE);
                 await step('select a scenario in the scenario list');
 
-                await DetailAreaPage.assertDetailsAreaExpanded();
+                await DetailAreaPage.assertDetailsExpanded();
                 await DetailAreaPage.assertSectionExpanded('Use Case');
                 await DetailAreaPage.assertSectionCollapsed('Labels');
                 await DetailAreaPage.assertSectionCollapsed('Webtest Class');
                 await step('Detailarea and important sections are expanded on first visit');
 
-                await DetailAreaPage.collapseDetailsSection('Use Case');
+                await DetailAreaPage.collapseSection('Use Case');
                 await DetailAreaPage.assertSectionCollapsed('Use Case');
-                await DetailAreaPage.expandDetailsSection('Labels');
+                await DetailAreaPage.expandSection('Labels');
                 await DetailAreaPage.assertSectionExpanded('Labels');
                 await step('Use Case section has been collapsed and Labels section expanded');
 
-                await DetailAreaPage.collapseDetailsArea();
-                await DetailAreaPage.assertDetailsAreaCollapsed();
+                await DetailAreaPage.collapseDetails();
+                await DetailAreaPage.assertDetailsCollapsed();
                 await step('Detailarea has been collapsed');
 
                 await Utils.refreshBrowser();
-                await DetailAreaPage.assertDetailsAreaCollapsed();
+                await DetailAreaPage.assertDetailsCollapsed();
                 await step('Collapsed detailarea is remembered on revisit.');
 
-                await DetailAreaPage.expandDetailsArea();
-                await DetailAreaPage.assertDetailsAreaExpanded();
+                await DetailAreaPage.expandDetails();
+                await DetailAreaPage.assertDetailsExpanded();
                 await step('Detailarea has been expanded');
 
                 await DetailAreaPage.assertSectionCollapsed('Use Case');

--- a/scenarioo-client/test/e2e/specs/browse_details.ts
+++ b/scenarioo-client/test/e2e/specs/browse_details.ts
@@ -7,8 +7,8 @@ import DetailAreaPage from '../pages/detailAreaPage';
 
 const SECOND_USE_CASE = 1;
 
-useCase('Browse Detailarea')
-    .description('The user is presented the detailarea (collapsed/expanded) as it is saved in the LocalStorage')
+useCase('Browse Details')
+    .description('The user can browse details sections and expanded/collapsed state is remembered on revisit')
     .describe(() => {
 
         beforeEach(async () => {
@@ -17,8 +17,8 @@ useCase('Browse Detailarea')
             await HomePage.assertPageIsDisplayed();
         });
 
-        scenario('Remembers collapsed state of details area and sections on usecases overview')
-            .description('States of detailarea and sections are correctly saved in LocalStorage.')
+        scenario('on usecases overview')
+            .description('Remembers collapsed state of details area and sections on usecases overview')
             .it(async () => {
                 await DetailAreaPage.assertDetailsExpanded();
                 await DetailAreaPage.assertSectionExpanded('Build');
@@ -50,8 +50,8 @@ useCase('Browse Detailarea')
                 await step('Build section has been expanded');
             });
 
-        scenario('Remembers collapsed state of details area and sections on scenarios overview')
-            .description('States of detailarea and sections are correctly saved in LocalStorage.')
+        scenario('on scenarios overview')
+            .description('Remembers collapsed state of details area and sections on scenarios overview')
             .it(async () => {
                 await HomePage.selectUseCase(SECOND_USE_CASE);
                 await step('select a scenario in the scenario list');

--- a/scenarioo-client/test/e2e/specs/list_use_cases.ts
+++ b/scenarioo-client/test/e2e/specs/list_use_cases.ts
@@ -34,18 +34,18 @@ useCase('List use cases')
                 await step('other filter applied: one use case found');
             });
 
-        scenario('Show and hide metadata')
+        scenario('Show and hide details')
             .it(async () => {
                 await HomePage.goToPage();
-                await step('display the homePage, metadata shown');
+                await step('display the use cases with expanded details');
                 await HomePage.assertPageIsDisplayed();
                 await HomePage.assertDetailsExpanded();
                 await HomePage.collapseDetails();
                 await HomePage.assertDetailsCollapsed();
-                await step('metadata hidden');
+                await step('details hidden');
                 await HomePage.expandDetails();
                 await HomePage.assertDetailsExpanded();
-                await step('metadata shown');
+                await step('details shown again');
             });
 
         scenario('Display Diff-Information')

--- a/scenarioo-client/test/e2e/specs/list_use_cases.ts
+++ b/scenarioo-client/test/e2e/specs/list_use_cases.ts
@@ -39,12 +39,12 @@ useCase('List use cases')
                 await HomePage.goToPage();
                 await step('display the homePage, metadata shown');
                 await HomePage.assertPageIsDisplayed();
-                await HomePage.assertMetaDataShown();
-                await HomePage.hideMetaData();
-                await HomePage.assertMetaDataHidden();
+                await HomePage.assertDetailsExpanded();
+                await HomePage.collapseDetails();
+                await HomePage.assertDetailsCollapsed();
                 await step('metadata hidden');
-                await HomePage.showMetaData();
-                await HomePage.assertMetaDataShown();
+                await HomePage.expandDetails();
+                await HomePage.assertDetailsExpanded();
                 await step('metadata shown');
             });
 


### PR DESCRIPTION
1. detailarea to take full height of viewport AND of page (if right content is higher than viewport)
2. detail area collapse arrow not to slide out of the arrow button box
3. detail area collapse arrow to be as much centered as possible
4. no table in layout css - use flex box instead
5. clean up some namings (no metadata anymore etc.)
6. clean up some css styles that should not be needed

