### PR TITLE
Feature/1002 migrate breadcrumb without needless observable complexity

### DIFF
--- a/scenarioo-client/app/build/mainpage/share/share.component.spec.ts
+++ b/scenarioo-client/app/build/mainpage/share/share.component.spec.ts
@@ -19,7 +19,7 @@ import {ShareComponent} from './share.component';
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {BrowserDynamicTestingModule, platformBrowserDynamicTesting} from '@angular/platform-browser-dynamic/testing';
 import {BsModalService, ModalModule} from 'ngx-bootstrap';
-import {HashLocationStrategy, Location, LocationStrategy, PlatformLocation} from '@angular/common';
+import {HashLocationStrategy, Location, LocationStrategy} from '@angular/common';
 import {LocationService} from '../../../shared/location.service';
 import {SharePageService} from '../../../shared/navigation/sharePage/sharePage.service';
 
@@ -77,30 +77,22 @@ describe('share component', () => {
 
     it('getPageUrl behaves correctly when url is set', () => {
         const sharePageService = fixture.debugElement.injector.get(SharePageService);
-        spyOn(sharePageService, 'getPageUrl').and.returnValue({
-            subscribe: (cb) => {
-                cb(URL);
-            },
-        });
+        spyOn(sharePageService, 'getPageUrl').and.returnValue(URL);
         component.ngOnInit();
+        const shareButton = fixture.nativeElement.querySelector('button');
+        void expect(shareButton).toBeDefined();
+        shareButton.click();
         void expect(component.pageUrl).toBe(URL);
     });
 
     it('getPageUrl behaves correctly when url is not set', () => {
         const sharePageService = fixture.debugElement.injector.get(SharePageService);
-        spyOn(sharePageService, 'getPageUrl').and.returnValue({
-            subscribe: (cb) => {
-                cb(undefined);
-            },
-        });
+        spyOn(sharePageService, 'getPageUrl').and.returnValue(undefined);
         component.ngOnInit();
+        const shareButton = fixture.nativeElement.querySelector('button');
+        void expect(shareButton).toBeDefined();
+        shareButton.click();
         void expect(component.pageUrl).toBe('http://localhost:7070/context.html');
-    });
-
-    it('should set data', () => {
-        const email = 'scenarioo@scenarioo.org';
-        component.eMailUrl = email;
-        void expect(component.eMailUrl).toBe(email);
     });
 
 });

--- a/scenarioo-client/app/build/mainpage/share/share.component.ts
+++ b/scenarioo-client/app/build/mainpage/share/share.component.ts
@@ -44,25 +44,10 @@ export class ShareComponent implements OnInit {
     }
 
     ngOnInit(): void {
-
-        // TODO: Workaround until the full migration, when the Angular router is available
-        // this.currentBrowserLocation = this.location.prepareExternalUrl(this.location.path());
-        this.currentBrowserLocation = (this.platformLocation as any).location.href;
-
-        this.sharePageService.getPageUrl().subscribe((pageUrl) => {
-            this.pageUrl = this.getPageUrl(pageUrl);
-            this.eMailUrl = encodeURIComponent(this.pageUrl);
-        });
-
-        this.sharePageService.getImageUrl().subscribe((imageUrl) => {
-            this.imageUrl = imageUrl;
-        });
-
-        this.eMailSubject = encodeURIComponent('Link to Scenarioo');
-
     }
 
-    public getPageUrl(pageUrl: string): string {
+    public getPageUrl(): string {
+        const pageUrl = this.sharePageService.getPageUrl();
         if (pageUrl === undefined) {
             return this.currentBrowserLocation;
         } else {
@@ -71,6 +56,17 @@ export class ShareComponent implements OnInit {
     }
 
     openShare(shareContent: TemplateRef<string>) {
+
+        // TODO: Workaround until the full migration, when the Angular router is available
+        // this.currentBrowserLocation = this.location.prepareExternalUrl(this.location.path());
+        this.currentBrowserLocation = (this.platformLocation as any).location.href;
+
+        // Get state from current share this page service to render in dialog.
+        this.pageUrl = this.getPageUrl();
+        this.eMailUrl = encodeURIComponent(this.pageUrl);
+        this.imageUrl = this.sharePageService.getImageUrl();
+        this.eMailSubject = encodeURIComponent('Link to Scenarioo');
+
         this.modalRef = this.modalService.show(shareContent);
     }
 

--- a/scenarioo-client/app/shared/navigation/sharePage/sharePage.service.ts
+++ b/scenarioo-client/app/shared/navigation/sharePage/sharePage.service.ts
@@ -7,32 +7,32 @@ declare var angular: angular.IAngularStatic;
 @Injectable()
 export class SharePageService {
 
-    private readonly pageUrl: ReplaySubject<string> = new ReplaySubject(1);
-    private readonly imageUrl: ReplaySubject<string> = new ReplaySubject(1);
+    private pageUrl: string;
+    private imageUrl: string;
 
     constructor() {
         this.invalidateUrls();
     }
 
     setPageUrl(pageUrl: string) {
-        this.pageUrl.next(pageUrl);
+        this.pageUrl = pageUrl;
     }
 
     setImageUrl(imageUrl: string) {
-        this.imageUrl.next(imageUrl);
+        this.imageUrl = imageUrl;
     }
 
-    getPageUrl(): Observable<string> {
+    getPageUrl(): string {
         return this.pageUrl;
     }
 
-    getImageUrl(): Observable<string> {
+    getImageUrl(): string {
         return this.imageUrl;
     }
 
     invalidateUrls() {
-        this.pageUrl.next(undefined);
-        this.imageUrl.next(undefined);
+        this.pageUrl = undefined;
+        this.imageUrl =  undefined;
     }
 }
 

--- a/scenarioo-client/app/step/step.html
+++ b/scenarioo-client/app/step/step.html
@@ -63,7 +63,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </sc-collapsable-panel>
 
         <sc-collapsable-panel title="Related Sketches" key="stepView-relatedSketches" initially-expanded="true"
-                              ng-show="hasAnyRelatedIssues()">
+                              ng-show="hasAnyRelatedIssues">
             <ul id="relatedSketches">
                 <li ng-repeat="issue in relatedIssues"><a href="" ng-click="goToIssue(issue)">{{issue.name}}</a></li>
             </ul>

--- a/scenarioo-client/test/spec/shared/navigation/sharePage/sharePage.service.spec.ts
+++ b/scenarioo-client/test/spec/shared/navigation/sharePage/sharePage.service.spec.ts
@@ -34,18 +34,12 @@ describe('SharePageService', () => {
 
     it('stores the page Url', (done) => {
         sharePageService.setPageUrl(URL);
-        sharePageService.getPageUrl().subscribe((value) => {
-            expect(value).toBe(URL);
-            done();
-        });
+        expect(sharePageService.getPageUrl()).toBe(URL);
     });
 
     it('stores the image Url', (done) => {
         sharePageService.setImageUrl(URL);
-        sharePageService.getImageUrl().subscribe((value) => {
-            expect(value).toBe(URL);
-            done();
-        });
+        expect(sharePageService.getImageUrl()).toBe(URL);
     });
 
     it('sets both URLs to undefined when the invalidateUrl method is called', async () => {
@@ -58,18 +52,8 @@ describe('SharePageService', () => {
     });
 
     async function expectBothUrlsAreUndefined() {
-        await new Promise((resolve) => {
-            sharePageService.getPageUrl().subscribe((value) => {
-                expect(value).toBeUndefined();
-                resolve();
-            });
-        });
-        await new Promise((resolve) => {
-            sharePageService.getImageUrl().subscribe((value) => {
-                expect(value).toBeUndefined();
-                resolve();
-            });
-        });
+        expect(sharePageService.getPageUrl()).toBeUndefined();
+        expect(sharePageService.getImageUrl()).toBeUndefined();
     }
 
 });

--- a/scenarioo-client/test/spec/shared/navigation/sharePage/sharePage.service.spec.ts
+++ b/scenarioo-client/test/spec/shared/navigation/sharePage/sharePage.service.spec.ts
@@ -28,30 +28,30 @@ describe('SharePageService', () => {
         sharePageService = new SharePageService();
     });
 
-    it('is initialized with undefined values by default', async () => {
-        await expectBothUrlsAreUndefined();
+    it('is initialized with undefined values by default', () => {
+        expectBothUrlsAreUndefined();
     });
 
-    it('stores the page Url', (done) => {
+    it('stores the page Url', () => {
         sharePageService.setPageUrl(URL);
         expect(sharePageService.getPageUrl()).toBe(URL);
     });
 
-    it('stores the image Url', (done) => {
+    it('stores the image Url', () => {
         sharePageService.setImageUrl(URL);
         expect(sharePageService.getImageUrl()).toBe(URL);
     });
 
-    it('sets both URLs to undefined when the invalidateUrl method is called', async () => {
+    it('sets both URLs to undefined when the invalidateUrl method is called', () => {
         sharePageService.setPageUrl(URL);
         sharePageService.setImageUrl(URL);
 
         sharePageService.invalidateUrls();
 
-        await expectBothUrlsAreUndefined();
+        expectBothUrlsAreUndefined();
     });
 
-    async function expectBothUrlsAreUndefined() {
+    function expectBothUrlsAreUndefined() {
         expect(sharePageService.getPageUrl()).toBeUndefined();
         expect(sharePageService.getImageUrl()).toBeUndefined();
     }


### PR DESCRIPTION
@StuckiSimon I think this is less complex and works - since the dialog is only opened after the state has been set already.