### PR TITLE
Improve Version Handling in Build & Backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Ignore .idea files except basic run configurations
+# Ignore .idea files except important common settings and run configurations
 /.idea
 !/.idea/codeStyleSettings.xml
 !/.idea/encodings.xml
@@ -7,7 +7,7 @@
 !/.idea/codeStyles
 !/.idea/runConfigurations
 !/.idea/inspectionProfiles
-
+!/.idea/gradle.xml
 
 classes/
 bin/

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="delegatedBuild" value="true" />
+        <option name="testRunner" value="CHOOSE_PER_TEST" />
+        <option name="distributionType" value="DEFAULT_WRAPPED" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$" />
+            <option value="$PROJECT_DIR$/scenarioo-client" />
+            <option value="$PROJECT_DIR$/scenarioo-docu-generation-example" />
+            <option value="$PROJECT_DIR$/scenarioo-server" />
+            <option value="$PROJECT_DIR$/scenarioo-validator" />
+          </set>
+        </option>
+        <option name="useQualifiedModuleNames" value="true" />
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -6,7 +6,7 @@
   <component name="ProjectPlainTextFileTypeManager">
     <file url="file://$PROJECT_DIR$/../scenarioo.github.io/_includes/css/main.css" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -1,39 +1,7 @@
-/**
- * Used Version of Scenarioo Java Library for reading scenarioo docu data
- */
-ext.scenariooApiVersion = '2.1.1'
+apply from: "version.gradle"
 
-/**
- * Internal scenarioo format version of produced aggregation data (internal server format version).
- *
- * On import this version is stored for each build, if the format of a build does not correspond to this format, the
- * build is automatically reimported again (all aggregation data recalculated in new format).
- *
- * First part of the version corresponds to library version that is supported, second part of the version depends on
- * internal aggregation format. the second part should be increased whenever something important is changed in the
- * internal format or the way that the aggregator is caluclating internal data on builds.
- */
-ext.scenariooAggregatedDataFormatVersion = '2.1.0'
-
-/**
- * Name of the release branch of this scenarioo version, which is used for links to the versioned documentation.
- */
-ext.documentationVersion = '5.0'
-
-/*
- * Gets the version name from the latest Git tag
- * From: http://ryanharter.com/blog/2013/07/30/automatic-versioning-with-git-and-gradle/
- */
-def getVersionName = { ->
-	def stdout = new ByteArrayOutputStream()
-	exec {
-		commandLine 'git', 'describe', '--tags'
-		standardOutput = stdout
-	}
-	return stdout.toString().trim()
-}
-
-ext.versionWithGitCommit = getVersionName();
+apply plugin: 'idea'
+idea.module.inheritOutputDirs = true
 
 buildscript {
 	repositories {
@@ -52,7 +20,7 @@ allprojects {
 	apply plugin: 'io.spring.dependency-management'
 
 	group = 'org.scenarioo'
-    version = getVersionName()
+    version = scenariooViewerVersion
 
     wrapper {
         gradleVersion = '6.7.1'

--- a/scenarioo-server/build.gradle
+++ b/scenarioo-server/build.gradle
@@ -105,34 +105,28 @@ eclipse {
   }
 }
 
-task createVersionPropertiesFile {
-	doLast {
-		def aggregatedDataFormatVersion = project.scenariooAggregatedDataFormatVersion
-		def apiVersion = project.scenariooApiVersion
-		def documentationVersion = project.documentationVersion
-
-		File versionFile = new File(sourceSets.main.output.classesDirs.getSingleFile().absolutePath + '/version.properties');
-		versionFile.write('version=' + versionWithGitCommit + '\n' +
-				'build-date=' + new Date() + '\n' +
-				'apiVersion=' + apiVersion + '\n' +
-				'aggregatedDataFormatVersion=' + aggregatedDataFormatVersion + '\n' +
-				'documentationVersion=' + documentationVersion + '\n')
-	}
+/**
+ * Replace properties in important resource files
+ */
+processResources {
+    filesMatching(['version.properties', 'banner.txt']) {
+        expand(project.properties)
+    }
 }
 
 bootJar {
     from('../scenarioo-client/dist') {
         into('static')
     }
-    archiveFileName = 'scenarioo-viewer-' + versionWithGitCommit + '.jar'
+    archiveFileName = 'scenarioo-viewer-' + archiveVersion.get() + '.jar'
 }
 
 bootJar.doLast {
     copy {
         from ('build/libs/')
         into ('build/libs/')
-        include('scenarioo-viewer-' + version + '.jar')
-        rename('scenarioo-viewer-' + version + '.jar', 'scenarioo-latest.jar')
+        include('scenarioo-viewer-' + archiveVersion.get() + '.jar')
+        rename('scenarioo-viewer-' + archiveVersion.get() + '.jar', 'scenarioo-latest.jar')
     }
 }
 
@@ -140,20 +134,18 @@ bootWar {
     from('../scenarioo-client/dist') {
         into('WEB-INF/classes/static')
     }
-    archiveFileName = 'scenarioo-viewer-' + versionWithGitCommit + '.war'
+    archiveFileName = 'scenarioo-viewer-' + archiveVersion.get() + '.war'
 }
 
 bootWar.doLast {
     copy {
         from ('build/libs/')
         into ('build/libs/')
-        include('scenarioo-viewer-' + versionWithGitCommit + '.war')
-        rename('scenarioo-viewer-' + versionWithGitCommit + '.war', 'scenarioo-latest.war')
+        include('scenarioo-viewer-' + archiveVersion.get() + '.war')
+        rename('scenarioo-viewer-' + archiveVersion.get() + '.war', 'scenarioo-latest.war')
     }
 }
 
-assemble.dependsOn createVersionPropertiesFile
-war.dependsOn createVersionPropertiesFile
 bootWar.dependsOn ":scenarioo-client:build"
 war.dependsOn ":scenarioo-client:build"
 

--- a/scenarioo-server/build.gradle
+++ b/scenarioo-server/build.gradle
@@ -152,7 +152,7 @@ publishing {
 
             groupId 'org.scenarioo'
             artifactId 'scenarioo-viewer'
-            version versionWithGitCommit
+            version scenariooViewerVersion
 
             pom {
                 name = 'Scenarioo Viewer'

--- a/scenarioo-server/src/main/java/org/scenarioo/dao/version/ApplicationVersionHolder.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/dao/version/ApplicationVersionHolder.java
@@ -16,37 +16,49 @@ public enum ApplicationVersionHolder {
 
 	private ApplicationVersion applicationVersion;
 
+	/**
+	 * Use this to simply initialize in spring boot app from resource files in class path
+	 */
 	public void initializeFromClassContext() {
-
-		final Properties properties = new Properties();
 		final InputStream inputStream = ApplicationVersionHolder.class.getResourceAsStream("/version.properties");
+		ApplicationVersionHolder.INSTANCE.initializeFromVersionPropertiesInputStream(inputStream);
+	}
+
+	/**
+	 * Use this to initialize from any input stream (e.g. from servlet context resource in a different web server scenario, like a tomcat war deployment)
+	 */
+	public void initializeFromVersionPropertiesInputStream(InputStream inputStream) {
 		if (inputStream == null) {
-			LOGGER.warn("version.properties not found, no real version information available.");
+			LOGGER.warn("version.properties not found, no real version information available. Continue with unknown version.");
 			ApplicationVersionHolder.INSTANCE.initialize("unknown", "unknown", "unknown", "unknown", "develop");
 		} else {
 			try {
+				final Properties properties = new Properties();
 				properties.load(inputStream);
 				ApplicationVersionHolder.INSTANCE.initializeFromProperties(properties);
 			} catch (final Exception e) {
-				LOGGER.warn("version.properties not found, no real version information available.", e);
+				LOGGER.warn("Could not load version.properties - no real version information available.", e);
 				ApplicationVersionHolder.INSTANCE.initialize("unknown", "unknown", "unknown", "unknown", "develop");
 			}
 		}
+		LOGGER.info("Version info loaded from version.properties:");
+		LOGGER.info("  Version: " + ApplicationVersionHolder.INSTANCE.getApplicationVersion().getVersion());
+		LOGGER.info("  Build date: " + ApplicationVersionHolder.INSTANCE.getApplicationVersion().getBuildDate());
 	}
 
-	public void initialize(final String version, final String buildDate, final String apiVersion,
-			final String aggregatedDataFormatVersion, String documentationVersion) {
-		applicationVersion = new ApplicationVersion(version, buildDate, apiVersion,
-				aggregatedDataFormatVersion, documentationVersion);
-	}
-
-	public void initializeFromProperties(final Properties versionProperties) {
+	private void initializeFromProperties(final Properties versionProperties) {
 		String version = versionProperties.getProperty("version");
 		String buildDate = versionProperties.getProperty("build-date");
 		String apiVersion = versionProperties.getProperty("apiVersion");
 		String aggregatedDataFormatVersion = versionProperties.getProperty("aggregatedDataFormatVersion");
 		String documentationVersion = versionProperties.getProperty("documentationVersion");
 		initialize(version, buildDate, apiVersion, aggregatedDataFormatVersion, documentationVersion);
+	}
+
+	private void initialize(final String version, final String buildDate, final String apiVersion,
+							final String aggregatedDataFormatVersion, String documentationVersion) {
+		applicationVersion = new ApplicationVersion(version, buildDate, apiVersion,
+				aggregatedDataFormatVersion, documentationVersion);
 	}
 
 	public ApplicationVersion getApplicationVersion() {

--- a/scenarioo-server/src/main/java/org/scenarioo/dao/version/ApplicationVersionHolder.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/dao/version/ApplicationVersionHolder.java
@@ -23,17 +23,15 @@ public enum ApplicationVersionHolder {
 		if (inputStream == null) {
 			LOGGER.warn("version.properties not found, no real version information available.");
 			ApplicationVersionHolder.INSTANCE.initialize("unknown", "unknown", "unknown", "unknown", "develop");
-			return;
+		} else {
+			try {
+				properties.load(inputStream);
+				ApplicationVersionHolder.INSTANCE.initializeFromProperties(properties);
+			} catch (final Exception e) {
+				LOGGER.warn("version.properties not found, no real version information available.", e);
+				ApplicationVersionHolder.INSTANCE.initialize("unknown", "unknown", "unknown", "unknown", "develop");
+			}
 		}
-
-		try {
-			properties.load(inputStream);
-			ApplicationVersionHolder.INSTANCE.initializeFromProperties(properties);
-		} catch (final Exception e) {
-			LOGGER.warn("version.properties not found, no real version information available.", e);
-			ApplicationVersionHolder.INSTANCE.initialize("unknown", "unknown", "unknown", "unknown", "develop");
-		}
-
 	}
 
 	public void initialize(final String version, final String buildDate, final String apiVersion,

--- a/scenarioo-server/src/main/java/org/scenarioo/rest/application/ScenariooInitializer.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/rest/application/ScenariooInitializer.java
@@ -88,17 +88,16 @@ public class ScenariooInitializer implements ServletContextInitializer {
 
 		final InputStream inputStream = servletContext.getResourceAsStream("/WEB-INF/classes/version.properties");
 		if (inputStream == null) {
-			LOGGER.warn("  version.properties not found, no version information available");
-			ApplicationVersionHolder.INSTANCE.initialize("unknown", "unknown", "unknown", "unknown", "develop");
-			return;
-		}
-
-		try {
-			properties.load(inputStream);
-			ApplicationVersionHolder.INSTANCE.initializeFromProperties(properties);
-		} catch (final Exception e) {
-			ApplicationVersionHolder.INSTANCE.initialize("unknown", "unknown", "unknown", "unknown", "develop");
-			LOGGER.warn("  version.properties not found, no version information available", e);
+			// just try using class context, which should work for spring boot app.
+			ApplicationVersionHolder.INSTANCE.initializeFromClassContext();
+		} else {
+			try {
+				properties.load(inputStream);
+				ApplicationVersionHolder.INSTANCE.initializeFromProperties(properties);
+			} catch (final Exception e) {
+				ApplicationVersionHolder.INSTANCE.initialize("unknown", "unknown", "unknown", "unknown", "develop");
+				LOGGER.warn("  version.properties not found, no version information available", e);
+			}
 		}
 
 		LOGGER.info("  Version: " + ApplicationVersionHolder.INSTANCE.getApplicationVersion().getVersion());

--- a/scenarioo-server/src/main/java/org/scenarioo/rest/application/ScenariooInitializer.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/rest/application/ScenariooInitializer.java
@@ -89,7 +89,7 @@ public class ScenariooInitializer implements ServletContextInitializer {
 			// just try using class context, which should work for spring boot app.
 			ApplicationVersionHolder.INSTANCE.initializeFromClassContext();
 		} else {
-			// load from input stream from servlet context otherwise
+			// load from input stream from servlet context otherwise (needed for some war deployment scenarios in a web server as a WAR)
 			ApplicationVersionHolder.INSTANCE.initializeFromVersionPropertiesInputStream(inputStream);
 		}
 	}

--- a/scenarioo-server/src/main/java/org/scenarioo/rest/application/ScenariooInitializer.java
+++ b/scenarioo-server/src/main/java/org/scenarioo/rest/application/ScenariooInitializer.java
@@ -84,24 +84,14 @@ public class ScenariooInitializer implements ServletContextInitializer {
 	}
 
 	private void initializeApplicationVersion(final ServletContext servletContext) {
-		final Properties properties = new Properties();
-
 		final InputStream inputStream = servletContext.getResourceAsStream("/WEB-INF/classes/version.properties");
 		if (inputStream == null) {
 			// just try using class context, which should work for spring boot app.
 			ApplicationVersionHolder.INSTANCE.initializeFromClassContext();
 		} else {
-			try {
-				properties.load(inputStream);
-				ApplicationVersionHolder.INSTANCE.initializeFromProperties(properties);
-			} catch (final Exception e) {
-				ApplicationVersionHolder.INSTANCE.initialize("unknown", "unknown", "unknown", "unknown", "develop");
-				LOGGER.warn("  version.properties not found, no version information available", e);
-			}
+			// load from input stream from servlet context otherwise
+			ApplicationVersionHolder.INSTANCE.initializeFromVersionPropertiesInputStream(inputStream);
 		}
-
-		LOGGER.info("  Version: " + ApplicationVersionHolder.INSTANCE.getApplicationVersion().getVersion());
-		LOGGER.info("  Build date: " + ApplicationVersionHolder.INSTANCE.getApplicationVersion().getBuildDate());
 	}
 
 	private void initializeContextPath(ServletContext servletContext) {

--- a/scenarioo-server/src/main/resources/banner.txt
+++ b/scenarioo-server/src/main/resources/banner.txt
@@ -13,5 +13,9 @@
 sy-    :ho  .yy:`   `:y+  /hs-    .+s.   /h:      yy   /ho-    .+hho   oh.      /h:   /ho- `- .+ho   :hs:`   ./hs`
 `/shyyhs/     :oyyyhyo:    `/syyyhy+-    /h:      yy    `/shyyhs+:ho   oh.      /h:    `/shyyhs+.     `/syhyhyo-
 
-
-:: Spring Boot ::		${spring-boot.formatted-version}
+:: Scenarioo Version                  ::  ${project.scenariooViewerVersion}
+:: Scenarioo Release Build Date       ::  ${project.buildDate}
+:: Scenarioo Documentation Version    ::  ${project.documentationVersion}
+:: Scenarioo Data Format Version      ::  ${project.scenariooApiVersion}
+:: Scenarioo Internal Format Version  ::  ${project.scenariooAggregatedDataFormatVersion}
+:: Spring Boot Version                :: \${spring-boot.formatted-version}

--- a/scenarioo-server/src/main/resources/version.properties
+++ b/scenarioo-server/src/main/resources/version.properties
@@ -1,0 +1,5 @@
+version=${project.scenariooViewerVersion}
+build-date=${project.buildDate}
+apiVersion=${project.scenariooApiVersion}
+aggregatedDataFormatVersion=${project.scenariooAggregatedDataFormatVersion}
+documentationVersion=${project.documentationVersion}

--- a/scenarioo-server/src/test/java/org/scenarioo/dao/version/ApplicationVersionHolderTest.java
+++ b/scenarioo-server/src/test/java/org/scenarioo/dao/version/ApplicationVersionHolderTest.java
@@ -1,0 +1,17 @@
+package org.scenarioo.dao.version;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class ApplicationVersionHolderTest {
+
+	@Test
+	public void initializeFromClassContext_loadsVersionProperlyFromVersionPropertiesFile() {
+		ApplicationVersionHolder.INSTANCE.initializeFromClassContext();
+		assertThat(ApplicationVersionHolder.INSTANCE.getApplicationVersion().getVersion()).isNotBlank();
+		assertThat(ApplicationVersionHolder.INSTANCE.getApplicationVersion().getVersion()).isNotEqualToIgnoringCase("unknown");
+		assertThat(ApplicationVersionHolder.INSTANCE.getApplicationVersion().getVersion()).describedAs("Version loaded from version.properties is not expected to contain unresolved property expression - Hint: use gradle to build to have proper resolved version.properties").doesNotContain("${");
+	}
+
+}

--- a/scenarioo-validator/build.gradle
+++ b/scenarioo-validator/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 
 distZip.doLast {
     copy {
-        String originalZipName = 'scenarioo-validator-' + versionWithGitCommit + '.zip';
+        String originalZipName = 'scenarioo-validator-' + archiveVersion.get() + '.zip';
         from('build/distributions/')
         into('build/distributions/')
         include(originalZipName)

--- a/version.gradle
+++ b/version.gradle
@@ -1,0 +1,49 @@
+/**
+ * Version of the scenarioo viewer web application.
+ * This version is taken from git version information via `git describe`
+ * which is a nice version number in case of a properly tagged release version
+ * or otherwise a version number including the git commit hash for any non-release versions (like developer snapshot releases).
+ */
+ext.scenariooViewerVersion = getVersionFromGit()
+
+/**
+ * Used Version of Scenarioo Java Library for reading scenarioo docu data
+ */
+ext.scenariooApiVersion = '2.1.1'
+
+/**
+ * Internal scenarioo format version of produced aggregation data (internal server format version).
+ *
+ * On import this version is stored for each build, if the format of a build does not correspond to this format, the
+ * build is automatically reimported again (all aggregation data recalculated in new format).
+ *
+ * First part of the version corresponds to library version that is supported, second part of the version depends on
+ * internal aggregation format. the second part should be increased whenever something important is changed in the
+ * internal format or the way that the aggregator is caluclating internal data on builds.
+ */
+ext.scenariooAggregatedDataFormatVersion = '2.1.0'
+
+/**
+ * Name of the release branch of this scenarioo version, which is used for links to the versioned documentation.
+ */
+ext.documentationVersion = '5.0'
+
+/**
+ * Build date for version properties file
+ */
+ext.buildDate = new Date()
+
+/**
+ * Gets the version name from the latest Git tag
+ * From: http://ryanharter.com/blog/2013/07/30/automatic-versioning-with-git-and-gradle/
+ */
+def getVersionFromGit() {
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'describe', '--tags'
+        standardOutput = stdout
+    }
+    def version = stdout.toString().trim()
+    println "Version from git: ${version}"
+    return version
+}


### PR DESCRIPTION
Improves the version handling in several aspects:
1. Works now when working with Spring Boot deployments - which seemed not to work before (could not load it from servlet context somehow)
2. refactored the version stuff into own gradle file to have all version stuff in one place
3. use resource processing of gradle to create version.properties file more elegantly
4. use same mechanism to also display version information as part of spring application banner in server log
5. use standard gradle version property in gradle files where appropriate (instead of deprecated version property or long scenarioo specific version property)